### PR TITLE
Document spec-only repo state for Cloud agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Repository state (as of this writing)
+
+This repository is currently **spec-only**. The only tracked source is
+`requirements.md`, a planning document for a project named
+`boilerplates-with-ai-skills`. There is **no application code, no package
+manifest, no lockfile, no services, and no build/test/run tooling yet**.
+
+Consequences for environment setup:
+
+- There is nothing to install, lint, build, test, or run end to end. Any
+  "run the app" request cannot be satisfied until an implementation exists.
+- The implementation stack is intentionally undecided in `requirements.md`
+  (the CLI is proposed as "Node.js or Python"). Do not assume a stack.
+- The startup update script is intentionally a guarded no-op today: it only
+  installs dependencies if a manifest appears later (`package.json` →
+  `npm install`). Update it once a real stack and manifests are added.
+
+### Available runtimes in the VM
+
+The base image already provides (versions may drift over time):
+
+- Node.js `v22.x` and npm `10.x`
+- Python `3.12.x`
+
+### When implementation begins
+
+Once boilerplates / a CLI are added, update this file and the Cloud startup
+update script to install the real dependencies (e.g. `npm install`, or
+`pip install`/`uv sync` for a Python CLI), and document the lint/test/build/run
+commands here.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting that this repository is currently **spec-only**.

## Why

The repository contains only `requirements.md` (a planning document for `boilerplates-with-ai-skills`). There is no application code, no package manifest, no lockfile, no services, and no build/test/run tooling. As a result there is nothing to install, lint, build, test, or run end to end yet.

This note captures durable, non-obvious context for future Cloud agents:
- The repo is spec-only; "run the app" cannot be satisfied until an implementation exists.
- The implementation stack is intentionally undecided in `requirements.md` (Node.js or Python).
- Available VM runtimes: Node.js `v22.x` / npm `10.x`, Python `3.12.x`.
- Guidance to update the startup script and this file once a real stack and manifests are added.

## Environment setup

The Cloud startup update script is set to a guarded no-op that will install Node dependencies automatically if/when a manifest appears:

```
if [ -f package-lock.json ]; then npm ci; elif [ -f package.json ]; then npm install; fi
```

No code was implemented, as building out the product from the spec would be a large scope change beyond environment setup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

