### PR TITLE
Add landscape review + getsuperpower evaluation for the spec

### DIFF
--- a/docs/getsuperpower-eval.md
+++ b/docs/getsuperpower-eval.md
@@ -1,0 +1,63 @@
+# getsuperpower — Install & Verification Notes
+
+Evaluation of `https://github.com/0xroylee/getsuperpower.git`, installed and run
+end-to-end to understand the closest existing tool to parts of our spec. See
+`docs/landscape-and-differentiation.md` for the strategic comparison.
+
+## What it is
+
+`getsuperpower` (npm `getsuperpower`, v0.3.3) is a **Bun + TypeScript CLI** that
+packages an entire agent workflow as one callable **skill tree**. A
+`workflow.json` declares an entry skill plus ordered sub-skill `steps` (with
+optional `human_approval` gates); the CLI installs the required skills across
+multiple agents and records the installed workflow under `.getsuperpower/`.
+
+- Runtime: Bun; deps are minimal (`commander`, `zod`, `@clack/prompts`,
+  `picocolors`).
+- Supported agent targets: Claude (`.claude/skills`), Codex/opencode/Copilot
+  (`.agents/skills`, Codex mirror `.codex/skills`), Cursor (`.cursor/rules`).
+- Skill sources: bundled, local dirs, Superpowers plugin cache,
+  Matt Pocock installs, and external git packages.
+- Commands: `init`, `validate`, `deps`, `install`/`clone`, `list`, `skills
+  install|update`, `onboard`, plus `bundle`/`workflow` compatibility aliases.
+
+## How to install & run (Bun required)
+
+```bash
+curl -fsSL https://bun.sh/install | bash      # if bun is not present
+export PATH="$HOME/.bun/bin:$PATH"
+bun install
+bun run build
+bun run ci:test         # non-e2e test suite
+./node_modules/.bin/biome check .
+bun run typecheck
+bun run dev -- --help   # run the CLI
+```
+
+## Verification results (this environment)
+
+- `bun install` → 15 packages installed, exit 0.
+- `bun run build` → bundled 100 modules → `dist/cli.js` (~0.71 MB).
+- `bun run ci:test` → **111 pass / 0 fail** (522 assertions, 12 files).
+- `biome check .` → **58 files, no issues**.
+- `tsc --noEmit` → clean.
+- End-to-end `init` → `validate` (valid, 3 steps / 4 skills) → `deps` →
+  `install --agents claude` (fetched Superpowers skills, wrote skills into
+  `~/.claude/skills`, created `.getsuperpower/workflows/<name>.json`) → `list`
+  (shows the installed workflow). All succeeded.
+
+## Gotchas observed
+
+- `validate`/`install` expect a **path-like** source; a bare relative name is
+  treated as an unsupported source. Use `./name` or an absolute path.
+- The install flag is `--agents` (plural), not `--agent`.
+- Some non-Claude agent targets ("PromptScript") reject global skill installs;
+  Claude/Codex/Cursor targets work.
+- AGENTS.md documents an `rtk`-prefixed command convention used by the project's
+  own Codex setup; plain `bun run ...` works fine locally.
+
+## Relevance to us
+
+Closest existing implementation of our **CLI + cross-agent skill install +
+authoring** goals. It does **not** scaffold project boilerplates and has **no
+security scanning** — those remain our differentiators (see the landscape doc).

--- a/docs/landscape-and-differentiation.md
+++ b/docs/landscape-and-differentiation.md
@@ -1,0 +1,177 @@
+# Landscape Review & How We Do Better
+
+A review of `requirements.md` (the `boilerplates-with-ai-skills` spec) against
+what already exists in the AI-agent-skill ecosystem as of mid-2026, plus a
+concrete plan for where this project can be genuinely better instead of
+duplicating existing tools.
+
+> This is a strategy/analysis document. It does not change product scope on its
+> own; it records findings so the spec can be sharpened before implementation.
+
+## 1. What the requirements ask for
+
+`requirements.md` proposes a GitHub hub that combines three things:
+
+1. **Boilerplates** — opinionated, production-ready starters for common stacks
+   (Next.js, FastAPI + React, Python AI, full-stack SaaS) that ship pre-wired
+   with agent config (`.claude/`, `.cursor/`, `.codex/`, `CLAUDE.md`,
+   `AGENTS.md`, `SKILL.md`).
+2. **Automated skill discovery/update** — CI that periodically finds, downloads,
+   categorizes, and indexes community/official skills.
+3. **Safety validation** — mandatory NVIDIA SkillSpector scanning with a risk
+   threshold gate, plus a CLI (`new`, `update-skills`, `scan-project`,
+   `list-boilerplates`, `search-skills`).
+
+The core bet is **"boilerplate + curated, security-vetted skills, cross-agent,
+one command."**
+
+## 2. What already exists outside (and overlaps)
+
+The single biggest finding: **most of the individual pieces already exist and
+are mature.** The novelty is not in any one capability but in the combination.
+
+### 2.1 The skill format is now a standard (not something to invent)
+
+- **Agent Skills / `SKILL.md`** is an open standard published by Anthropic at
+  [agentskills.io](https://agentskills.io/specification) (Dec 2025) and adopted
+  by Claude Code, OpenAI Codex, Gemini CLI, OpenClaw and others. Only `name` +
+  `description` are required; progressive disclosure (name/desc at startup, body
+  on activation, references on demand) is baked in.
+- Implication: we should **consume and comply with** this spec, not define our
+  own. Portability is the standard's selling point.
+
+### 2.2 Skill frameworks / methodologies
+
+- **obra/superpowers** — a very large, popular "agentic skills framework &
+  methodology" (TDD, brainstorming, debugging, plans, code review, worktrees,
+  subagent-driven dev). Ships via the official Claude plugin marketplace and
+  git-backed installs for Codex/Copilot/Gemini/OpenCode/Cursor. Skills activate
+  automatically by context.
+- **mattpocock/skills** — another curated skill set, referenced as an external
+  dependency by workflow bundles.
+
+### 2.3 getsuperpower (the repo we were asked to install)
+
+`0xroylee/getsuperpower` (installed and verified here — see
+`docs/getsuperpower-eval.md`) is the closest existing thing to parts of our
+spec. It is a Bun + TypeScript CLI that:
+
+- Packages a **whole workflow as one callable "skill tree"** (`workflow.json`
+  entry skill + ordered sub-skill steps with `human_approval` gates).
+- **Installs skills across agents** (Claude `.claude/skills`, Codex/opencode/
+  Copilot `.agents/skills`, Cursor `.cursor/rules`) from bundled, local,
+  Superpowers, Matt Pocock, or external git sources.
+- Provides `init`/`validate`/`deps`/`install`/`clone`/`list` and an authoring
+  helper skill, with a 90% coverage gate and a dependency-recency policy.
+
+It overlaps heavily with our **CLI + skill install/update + cross-agent** goals.
+It does **not** do boilerplate/project scaffolding, and it does **not**
+integrate security scanning (SkillSpector). Those are our openings.
+
+### 2.4 Discovery, directories & marketplaces (the "index" is solved)
+
+Our "automated discovery + central index" goal is a crowded space:
+
+| Directory / marketplace | Focus | Approx. size |
+| --- | --- | --- |
+| SkillsMP (skillsmp.com) | Agent Skills marketplace | 66,500+ |
+| agentskill.sh | Cross-tool skills directory | 274,000+ (claimed) |
+| awesomeagentskills.dev | Auto-updating skills + MCP + rules | 26,000+ |
+| cursor.directory | Cursor/Windsurf rules + MCP (one-click) | 1,000+ rules, 250K+ users |
+| MCP.so / Glama / PulseMCP / Smithery | MCP server directories | 4,000–18,000+ |
+| ClawHub | OpenClaw skills registry | 5,700+ |
+| philipbankier/awesome-agent-skills, VoltAgent/awesome-agent-skills | Cross-platform awesome lists | — |
+
+Building "yet another crawler + index" would compete with well-funded,
+already-large directories and is the weakest part of the spec.
+
+### 2.5 Boilerplate scaffolding (also solved as a primitive)
+
+- `create-next-app`, `degit`, `cookiecutter`, Yeoman, and thousands of GitHub
+  template repos already scaffold projects.
+- `PatrickJS/awesome-cursorrules` and cursor.directory already distribute
+  editor rule sets.
+- So "scaffold a project" is a commodity; "scaffold a project **that comes with
+  vetted, cross-agent skills already wired in**" is not.
+
+### 2.6 Security scanning (a real, differentiated primitive — use it, don't rebuild it)
+
+- **NVIDIA SkillSpector** is purpose-built for exactly our safety goal: 68
+  vulnerability patterns across 17 categories (prompt injection, data
+  exfiltration, excessive agency, MCP tool poisoning, taint tracking, YARA,
+  OSV.dev CVE lookups), two-stage static + optional LLM analysis, 0–100 risk
+  score, SARIF/JSON/Markdown output, baseline suppression, and CI-friendly exit
+  codes (`1` if `risk_score > 50`, `2` on error). Research it cites: 26.1% of
+  skills have vulnerabilities, 5.2% show likely malicious intent.
+- Implication: our value is **operationalizing** SkillSpector as a gate, not
+  reimplementing a scanner.
+
+## 3. Honest assessment of the spec
+
+| Spec pillar | Verdict | Why |
+| --- | --- | --- |
+| Invent skill format | ❌ Drop | `SKILL.md` is a standard; comply instead. |
+| Boilerplates pre-wired with agent config | ✅ Keep — differentiator | No mature product ties starters + vetted skills together. |
+| Cross-agent skill install/update CLI | ⚠️ Reuse | getsuperpower/superpowers already do this well; extend or build on, don't clone. |
+| Automated discovery + central index | ⚠️ De-prioritize | Many large directories already exist; hard to win. |
+| SkillSpector safety gate | ✅ Keep — differentiator | Nobody bundles boilerplates + a security gate; SkillSpector makes it cheap. |
+| CLI (`new`, `scan-project`, ...) | ✅ Keep | But scope tightly around the two differentiators. |
+
+## 4. How we do better (recommended positioning)
+
+Reframe the project from "another skills hub" to:
+
+> **Security-vetted, cross-agent project boilerplates**: `npx` a starter for
+> your stack and get a working project *plus* a curated set of skills that have
+> **passed a SkillSpector gate**, wired for Claude/Cursor/Codex/Copilot, with a
+> reproducible provenance report checked into the repo.
+
+Concrete ways to be better than each incumbent:
+
+1. **Be the only "starter + vetted skills" bundle.** Directories give you a
+   pile of skills; we give a *runnable project* with a *small, opinionated,
+   scanned* skill set already installed and aligned to the stack. This is the
+   one gap no incumbent fills.
+2. **Make security a first-class, visible gate — not a footnote.** Run
+   SkillSpector in CI for every bundled/updated skill, fail the build above a
+   configurable threshold, and commit `safety-reports/*.sarif` + a human summary
+   so users can *see* why a skill was included. Surface the risk score in the
+   README badge and in `scan-project` output.
+3. **Stand on the standard + existing installers, don't fork them.** Emit
+   spec-compliant `SKILL.md`, and either (a) build on getsuperpower's
+   `workflow.json` skill-tree + multi-agent installer, or (b) reuse Superpowers
+   as an upstream skill source. Contributing a "scan gate" upstream to
+   getsuperpower may be higher-leverage than a parallel CLI.
+4. **Curate, don't crawl.** Ship a *small, human-reviewed* catalog per
+   boilerplate with pinned versions + provenance, instead of racing 270k-entry
+   directories on breadth. Trust and reproducibility beat volume for teams.
+5. **Reproducibility & provenance.** Pin skill sources by commit, record a
+   lockfile of installed skills + their scan scores, and support deterministic
+   re-installs and re-scans (`scan-project`) so enterprises can audit.
+6. **Cross-agent parity as a guarantee, tested in CI.** getsuperpower already
+   maps agent homes; we should test that each boilerplate's skills install and
+   load on every supported agent, and publish a compatibility matrix.
+
+## 5. Suggested scope cut for Phase 1
+
+Drop/defer the crawler + central index. Ship instead:
+
+1. **2 boilerplates** (e.g. Next.js AI-first, FastAPI + React) each with a tiny,
+   scanned skill set wired for all supported agents.
+2. **SkillSpector CI gate** producing committed `safety-reports/` + a badge.
+3. **A thin CLI** — `new <boilerplate>` (scaffold) and `scan-project`
+   (re-scan) — ideally layered on getsuperpower/Superpowers rather than a
+   from-scratch installer.
+4. **Provenance lockfile** for installed skills.
+
+This keeps the two real differentiators (starter+skills bundling, and a visible
+security gate) and avoids competing where strong incumbents already exist.
+
+## 6. Key references
+
+- Agent Skills spec: https://agentskills.io/specification
+- Superpowers: https://github.com/obra/superpowers
+- getsuperpower: https://github.com/0xroylee/getsuperpower
+- NVIDIA SkillSpector: https://github.com/NVIDIA/SkillSpector
+- Directories: cursor.directory, skillsmp.com, awesomeagentskills.dev,
+  agentskill.sh, https://github.com/philipbankier/awesome-agent-skills


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds two analysis docs to inform `requirements.md` before implementation:

- `docs/getsuperpower-eval.md` — install & verification notes for `0xroylee/getsuperpower` (the closest existing tool), including how to run it and results in this environment.
- `docs/landscape-and-differentiation.md` — review of the spec against the current AI-agent-skill ecosystem, with a recommended positioning and a Phase‑1 scope cut.

## Why

The user asked to install `getsuperpower`, review `requirements.md`, check what already exists outside, and identify how we can do better.

## Key findings

- The `SKILL.md` format is now an **open standard** (agentskills.io, adopted by Claude/Codex/Gemini/OpenClaw). We should **comply**, not invent.
- **getsuperpower** (installed & verified: `bun install`/`build`, 111 tests pass, biome clean, `tsc` clean, full `init`→`validate`→`install`→`list` lifecycle) already covers the **cross-agent CLI + skill install/authoring** goal — but does **no boilerplate scaffolding** and **no security scanning**.
- **Superpowers** (obra) and many **directories/marketplaces** (SkillsMP, agentskill.sh, awesomeagentskills.dev, cursor.directory, MCP.so, Smithery, ClawHub) already own the "index/discovery" space — a weak place to compete.
- **Boilerplate scaffolding** (`create-next-app`, `degit`, `cookiecutter`, awesome-cursorrules) is commodity.
- **NVIDIA SkillSpector** already provides a purpose-built security scanner (68 patterns, SARIF, risk score, CI exit codes) — operationalize it, don't rebuild it.

## Recommended "how we do better"

Reposition from "another skills hub" to **security-vetted, cross-agent project boilerplates**: two differentiators nobody bundles today — (1) starters that ship with a small, **SkillSpector-gated** skill set wired for all agents, and (2) a **visible security gate** with committed `safety-reports/` + provenance lockfile. Drop the crawler/central index for Phase 1; build on getsuperpower/Superpowers rather than cloning them.

Details, tables, and references are in the docs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

