### PR TITLE
Add bwai search-skills: skill discovery + SkillSpector risk tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ bwai new node-service ./my-app --agents claude,cursor
 
 # Run the SkillSpector safety gate over the project's skills
 bwai scan-project ./my-app --threshold 50
+
+# Discover recently-updated skills from public hubs (GitHub + SkillsMP)
+bwai search-skills testing --limit 10
+# ...and score the top results with SkillSpector while you browse
+bwai search-skills "code review" --scan 3
 ```
 
 `bwai new` copies the boilerplate template, installs the curated skills into a
@@ -43,6 +48,21 @@ canonical `.bwai/skills/` plus each agent's skill directory
 (`.claude/skills/`, `.cursor/rules/`, `.codex/skills/`, `.agents/skills/`), and
 writes `skills.lock` with each skill's source, SHA-256, install targets, and
 scan status.
+
+## Discovering skills
+
+`bwai search-skills <query>` queries public hubs for recently-updated agent
+skills and merges the results (newest first):
+
+- **GitHub** repo search filtered by the `claude-skill` topic (works
+  unauthenticated; set `GITHUB_TOKEN` for a higher rate limit).
+- **SkillsMP** marketplace REST API (`sortBy=recent`; set `SKILLSMP_API_KEY`
+  for higher limits).
+
+Pass `--scan <n>` to run the SkillSpector scanner over the top `n` results and
+print each one's risk score — useful for triaging newly-discovered skills before
+promoting any into a boilerplate. Use `--source github|skillsmp|all` and
+`--sort recent|stars` to tune the query.
 
 ## The safety gate
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,13 @@ import { scaffold } from "./scaffold.js";
 import { parseAgents, type AgentId } from "./agents.js";
 import { scanProject, SkillSpectorScanner } from "./scan.js";
 import { getBoilerplate } from "./catalog.js";
+import {
+  GitHubSkillSource,
+  SkillsMpSkillSource,
+  searchSkills,
+  type SkillSource,
+  type SortOrder,
+} from "./discovery.js";
 
 const program = new Command();
 
@@ -106,6 +113,76 @@ program
         process.exitCode = 1;
       } else {
         console.log(`Safety gate passed (threshold ${report.threshold}).`);
+      }
+    },
+  );
+
+program
+  .command("search-skills")
+  .alias("search")
+  .argument("[query]", "keyword to search for (e.g. testing, security)", "")
+  .option("-s, --source <source>", "github | skillsmp | all", "all")
+  .option("-l, --limit <n>", "max results", "10")
+  .option("--sort <order>", "recent | stars", "recent")
+  .option("--scan <n>", "scan the top N results with SkillSpector and show risk scores", "0")
+  .description("Discover recently-updated agent skills from public hubs.")
+  .action(
+    async (query: string, opts: { source: string; limit: string; sort: string; scan: string }) => {
+      const limit = Number.parseInt(opts.limit, 10);
+      const scanTop = Number.parseInt(opts.scan, 10) || 0;
+      const sort: SortOrder = opts.sort === "stars" ? "stars" : "recent";
+
+      const sources: SkillSource[] = [];
+      if (opts.source === "all" || opts.source === "github") {
+        sources.push(new GitHubSkillSource());
+      }
+      if (opts.source === "all" || opts.source === "skillsmp") {
+        sources.push(new SkillsMpSkillSource());
+      }
+      if (sources.length === 0) {
+        throw new Error(`Invalid --source: ${opts.source} (expected github, skillsmp, or all).`);
+      }
+
+      const { candidates, errors } = await searchSkills(sources, query, {
+        sort,
+        limit: Number.isNaN(limit) ? 10 : limit,
+      });
+
+      for (const err of errors) {
+        console.error(`[${err.source}] ${err.message}`);
+      }
+      if (candidates.length === 0) {
+        console.log("No skills found.");
+        return;
+      }
+
+      const scanner = new SkillSpectorScanner();
+      const scannerReady = scanTop > 0 ? await scanner.isAvailable() : false;
+      if (scanTop > 0 && !scannerReady) {
+        console.error(
+          "SkillSpector not found on PATH; showing results without risk scores. " +
+            "Install with `uv tool install git+https://github.com/NVIDIA/skillspector.git`.",
+        );
+      }
+
+      let index = 0;
+      for (const c of candidates) {
+        index += 1;
+        const updated = c.updatedAt ? c.updatedAt.slice(0, 10) : "unknown";
+        console.log(`${index}. ${c.fullName}  [${c.source}]  ★${c.stars}  updated ${updated}`);
+        if (c.description) console.log(`   ${c.description.slice(0, 100)}`);
+        console.log(`   ${c.url}`);
+        if (scannerReady && index <= scanTop && c.url) {
+          try {
+            const result = await scanner.scan(c.url, { useLlm: false });
+            const verdict = result.riskScore > 50 ? "HIGH RISK" : "ok";
+            console.log(
+              `   SkillSpector: risk ${result.riskScore} (${verdict}), ${result.findings} finding(s)`,
+            );
+          } catch (e) {
+            console.log(`   SkillSpector: scan failed (${e instanceof Error ? e.message : e})`);
+          }
+        }
       }
     },
   );

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -1,0 +1,199 @@
+export type SortOrder = "recent" | "stars";
+
+export interface SkillCandidate {
+  /** Short skill/repo name. */
+  name: string;
+  /** owner/name or author/name identifier. */
+  fullName: string;
+  /** Canonical URL (usually a GitHub URL). */
+  url: string;
+  stars: number;
+  /** ISO 8601 last-updated timestamp, or null if unknown. */
+  updatedAt: string | null;
+  source: string;
+  description?: string;
+}
+
+export interface SearchOptions {
+  sort?: SortOrder;
+  limit?: number;
+}
+
+export interface SkillSource {
+  readonly name: string;
+  search(query: string, opts: SearchOptions): Promise<SkillCandidate[]>;
+}
+
+/** Minimal fetch signature so tests can inject a fake implementation. */
+export type FetchLike = (
+  url: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+}>;
+
+const defaultFetch: FetchLike = (url, init) => fetch(url, init) as unknown as ReturnType<FetchLike>;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function num(value: unknown): number {
+  return typeof value === "number" ? value : 0;
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Discover skill repositories via the GitHub Search API. Uses repo search
+ * (works unauthenticated) filtered by the `claude-skill` topic, sorted by most
+ * recently pushed. Honors an optional token for higher rate limits.
+ */
+export class GitHubSkillSource implements SkillSource {
+  readonly name = "github";
+
+  constructor(
+    private readonly fetchImpl: FetchLike = defaultFetch,
+    private readonly token: string | undefined = process.env.GITHUB_TOKEN,
+  ) {}
+
+  async search(query: string, opts: SearchOptions): Promise<SkillCandidate[]> {
+    const limit = clampLimit(opts.limit);
+    const sort = opts.sort === "stars" ? "stars" : "updated";
+    const q = [query.trim(), "topic:claude-skill"].filter(Boolean).join(" ");
+    const url =
+      `https://api.github.com/search/repositories?q=${encodeURIComponent(q)}` +
+      `&sort=${sort}&order=desc&per_page=${limit}`;
+
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "boilerplates-with-ai-skills",
+    };
+    if (this.token) headers.Authorization = `Bearer ${this.token}`;
+
+    const res = await this.fetchImpl(url, { headers });
+    if (!res.ok) {
+      if (res.status === 403 && !this.token) {
+        throw new Error(
+          "GitHub API rate limit reached (unauthenticated). Set GITHUB_TOKEN for a higher limit.",
+        );
+      }
+      throw new Error(`GitHub search failed: HTTP ${res.status}`);
+    }
+    const body = asRecord(await res.json());
+    const items = Array.isArray(body.items) ? body.items : [];
+    return items.slice(0, limit).map((raw): SkillCandidate => {
+      const item = asRecord(raw);
+      return {
+        name: str(item.name) ?? "unknown",
+        fullName: str(item.full_name) ?? "unknown",
+        url: str(item.html_url) ?? "",
+        stars: num(item.stargazers_count),
+        updatedAt: str(item.pushed_at) ?? str(item.updated_at) ?? null,
+        source: this.name,
+        description: str(item.description),
+      };
+    });
+  }
+}
+
+/** Discover skills via the SkillsMP marketplace REST API. */
+export class SkillsMpSkillSource implements SkillSource {
+  readonly name = "skillsmp";
+
+  constructor(
+    private readonly fetchImpl: FetchLike = defaultFetch,
+    private readonly apiKey: string | undefined = process.env.SKILLSMP_API_KEY,
+  ) {}
+
+  async search(query: string, opts: SearchOptions): Promise<SkillCandidate[]> {
+    const q = query.trim();
+    if (!q) {
+      // SkillsMP requires a keyword; wildcard searches are unsupported.
+      return [];
+    }
+    const limit = clampLimit(opts.limit);
+    const sortBy = opts.sort === "stars" ? "stars" : "recent";
+    const url =
+      `https://skillsmp.com/api/v1/skills/search?q=${encodeURIComponent(q)}` +
+      `&sortBy=${sortBy}&limit=${limit}`;
+
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+    const res = await this.fetchImpl(url, { headers });
+    if (!res.ok) {
+      throw new Error(`SkillsMP search failed: HTTP ${res.status}`);
+    }
+    const body = asRecord(await res.json());
+    const data = asRecord(body.data);
+    const skills = Array.isArray(data.skills) ? data.skills : [];
+    return skills.slice(0, limit).map((raw): SkillCandidate => {
+      const skill = asRecord(raw);
+      const author = str(skill.author) ?? "unknown";
+      const name = str(skill.name) ?? "unknown";
+      return {
+        name,
+        fullName: `${author}/${name}`,
+        url: str(skill.githubUrl) ?? str(skill.skillUrl) ?? "",
+        stars: num(skill.stars),
+        updatedAt: toIso(skill.updatedAt),
+        source: this.name,
+        description: str(skill.description),
+      };
+    });
+  }
+}
+
+/** SkillsMP returns updatedAt as a unix-seconds string; normalize to ISO. */
+function toIso(value: unknown): string | null {
+  const raw = typeof value === "string" ? Number.parseInt(value, 10) : num(value);
+  if (!Number.isFinite(raw) || raw <= 0) return null;
+  return new Date(raw * 1000).toISOString();
+}
+
+function clampLimit(limit: number | undefined): number {
+  const n = limit ?? 10;
+  if (Number.isNaN(n)) return 10;
+  return Math.min(Math.max(1, Math.trunc(n)), 100);
+}
+
+export interface AggregateResult {
+  candidates: SkillCandidate[];
+  errors: Array<{ source: string; message: string }>;
+}
+
+/** Run all sources, merge, sort, and collect per-source errors without failing. */
+export async function searchSkills(
+  sources: SkillSource[],
+  query: string,
+  opts: SearchOptions,
+): Promise<AggregateResult> {
+  const candidates: SkillCandidate[] = [];
+  const errors: AggregateResult["errors"] = [];
+
+  const settled = await Promise.allSettled(sources.map((s) => s.search(query, opts)));
+  settled.forEach((result, index) => {
+    const sourceName = sources[index]?.name ?? "unknown";
+    if (result.status === "fulfilled") {
+      candidates.push(...result.value);
+    } else {
+      const message =
+        result.reason instanceof Error ? result.reason.message : String(result.reason);
+      errors.push({ source: sourceName, message });
+    }
+  });
+
+  candidates.sort((a, b) => {
+    if (opts.sort === "stars") return b.stars - a.stars;
+    return (b.updatedAt ?? "").localeCompare(a.updatedAt ?? "");
+  });
+
+  const limit = clampLimit(opts.limit);
+  return { candidates: candidates.slice(0, limit), errors };
+}

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  GitHubSkillSource,
+  SkillsMpSkillSource,
+  searchSkills,
+  type FetchLike,
+} from "../src/discovery.js";
+
+function jsonResponse(body: unknown, status = 200): ReturnType<FetchLike> {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+}
+
+describe("GitHubSkillSource", () => {
+  it("maps repo search results and requests recency sort", async () => {
+    let calledUrl = "";
+    const fetchImpl: FetchLike = (url) => {
+      calledUrl = url;
+      return jsonResponse({
+        items: [
+          {
+            name: "cool-skill",
+            full_name: "acme/cool-skill",
+            html_url: "https://github.com/acme/cool-skill",
+            stargazers_count: 42,
+            pushed_at: "2026-07-01T00:00:00Z",
+            description: "A cool skill",
+          },
+        ],
+      });
+    };
+    const source = new GitHubSkillSource(fetchImpl, undefined);
+    const results = await source.search("testing", { sort: "recent", limit: 5 });
+
+    expect(calledUrl).toContain("topic%3Aclaude-skill");
+    expect(calledUrl).toContain("sort=updated");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      name: "cool-skill",
+      fullName: "acme/cool-skill",
+      stars: 42,
+      updatedAt: "2026-07-01T00:00:00Z",
+      source: "github",
+    });
+  });
+
+  it("gives a helpful error on unauthenticated rate limit", async () => {
+    const fetchImpl: FetchLike = () => jsonResponse({}, 403);
+    const source = new GitHubSkillSource(fetchImpl, undefined);
+    await expect(source.search("x", {})).rejects.toThrow(/rate limit/i);
+  });
+});
+
+describe("SkillsMpSkillSource", () => {
+  it("normalizes unix-seconds updatedAt to ISO and requires a query", async () => {
+    const fetchImpl: FetchLike = () =>
+      jsonResponse({
+        success: true,
+        data: {
+          skills: [
+            {
+              name: "testing",
+              author: "alice",
+              description: "TDD helper",
+              githubUrl: "https://github.com/alice/testing",
+              stars: 3,
+              updatedAt: "1783074096",
+            },
+          ],
+        },
+      });
+    const source = new SkillsMpSkillSource(fetchImpl, undefined);
+
+    expect(await source.search("", {})).toEqual([]); // no wildcard search
+
+    const results = await source.search("testing", { sort: "recent" });
+    expect(results[0]).toMatchObject({
+      name: "testing",
+      fullName: "alice/testing",
+      stars: 3,
+      source: "skillsmp",
+    });
+    expect(results[0]?.updatedAt).toBe(new Date(1783074096 * 1000).toISOString());
+  });
+});
+
+describe("searchSkills aggregation", () => {
+  const github = new GitHubSkillSource(
+    () =>
+      jsonResponse({
+        items: [
+          {
+            name: "b",
+            full_name: "o/b",
+            html_url: "u",
+            stargazers_count: 1,
+            pushed_at: "2026-07-02T00:00:00Z",
+          },
+        ],
+      }),
+    undefined,
+  );
+  const failing = {
+    name: "skillsmp",
+    async search() {
+      throw new Error("boom");
+    },
+  };
+
+  it("merges, sorts by recency, and collects per-source errors", async () => {
+    const { candidates, errors } = await searchSkills([github, failing], "q", {
+      sort: "recent",
+      limit: 10,
+    });
+    expect(candidates.map((c) => c.name)).toEqual(["b"]);
+    expect(errors).toEqual([{ source: "skillsmp", message: "boom" }]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `bwai search-skills <query>` — the foundational discovery command that both the "exploratory" and "promotion" directions need.

- **Sources** (`src/discovery.ts`): `GitHubSkillSource` (repo search filtered by `topic:claude-skill`, sorted by most-recently-pushed; optional `GITHUB_TOKEN`) and `SkillsMpSkillSource` (SkillsMP REST `sortBy=recent`; optional `SKILLSMP_API_KEY`). Results are merged and sorted newest-first. Fetch is injectable for testing; per-source failures are collected, not fatal.
- **Command**: `search-skills [query] --source github|skillsmp|all --limit N --sort recent|stars --scan N`. `--scan N` runs the **NVIDIA SkillSpector** scanner over the top N results and prints each one's risk score — discovery + risk tracking in one step.

## Verification

- ✅ `npm run lint`, `npm run typecheck`, `npm run build`
- ✅ `npm test` — 18 passed (4 new discovery tests with a fake fetch: mapping, rate-limit error, unix→ISO time, aggregation + error collection)
- ✅ Live smoke test against real GitHub + SkillsMP (recency-sorted merge)
- ✅ Live `--scan` with real SkillSpector v2.3.9: a 152★ recently-updated skill scored **risk 60 (HIGH RISK, 4 findings)** while another scored 25 (ok) — demonstrating why "most-updated" must be paired with scanning.

[bwai_search_skills_demo.log](https://cursor.com/agents/bc-a8de4f6a-a148-48fe-943d-747c48349690/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbwai_search_skills_demo.log)

## Notes / next steps

This is Phase 1 of the discovery pipeline. It is intentionally direction-independent: it feeds either an exploratory bundle or a promotion-to-curated-boilerplate flow. Proposed follow-ups (pending direction): a tracked skills index with score history (`registry/skills-index.json`), an `exploratory` bundle of latest gate-passing skills, and a scheduled re-scan job that opens PRs when a pinned skill's risk regresses.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

