### PR TITLE
Add Vercel-style boilerplates: nextjs-app and express-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ See [`requirements.md`](./requirements.md) for the full spec and
 for why this project focuses on *bundling starters with vetted skills* and a
 *security gate* rather than reinventing skill formats, installers, or directories.
 
-> Status: Phase 1 foundation — one boilerplate (`node-service`), the `bwai`
-> CLI (`list-boilerplates`, `new`, `scan-project`), a `skills.lock` provenance
-> file, and a SkillSpector safety gate wired into CI.
+> Status: Phase 1 foundation — the `bwai` CLI (`list-boilerplates`, `new`,
+> `search-skills`, `scan-project`), a `skills.lock` provenance file, and a
+> SkillSpector safety gate wired into CI.
+>
+> Boilerplates: `nextjs-app` (Next.js App Router + React + TS), `express-api`
+> (Express.js on Vercel), and `node-service` (minimal Node ESM).
 
 ## Install / develop
 

--- a/boilerplates/express-api/boilerplate.json
+++ b/boilerplates/express-api/boilerplate.json
@@ -1,0 +1,8 @@
+{
+  "name": "express-api",
+  "description": "Express.js (ESM) API starter deployable to Vercel, with zero-dependency HTTP tests and a curated, security-vetted skill set for AI agents.",
+  "stack": "express",
+  "version": "0.1.0",
+  "defaultAgents": ["claude", "cursor", "codex", "copilot"],
+  "skills": [{ "name": "express-api-design" }, { "name": "test-driven-development" }]
+}

--- a/boilerplates/express-api/skills/express-api-design/SKILL.md
+++ b/boilerplates/express-api/skills/express-api-design/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: express-api-design
+description: Use when adding or changing routes, middleware, or error handling in this Express.js API, to keep endpoints consistent, validated, and testable.
+---
+
+# Express API Design
+
+## Overview
+
+Keep the Express app small, testable, and consistent. Build routes on the
+exported `createApp()` factory so they can be tested without binding a port.
+
+## Process
+
+1. Add the route to `src/app.js` on the app returned by `createApp()`.
+2. Validate and parse input explicitly; never trust request bodies or params.
+3. Return JSON for API routes with a clear shape and correct status codes
+   (200/201 success, 400 client error, 404 not found, 500 server error).
+4. Centralize error handling with an error-handling middleware; do not leak
+   stack traces in responses.
+5. Add a `test/` case that starts the app on an ephemeral port and asserts the
+   response.
+
+## Guidelines
+
+- Keep handlers thin; move non-trivial logic into small functions you can unit
+  test.
+- Prefer explicit routes over broad catch-alls.
+- Do not read secrets from the request; read configuration from environment
+  variables at startup.
+- Keep responses deterministic and documented in the README.

--- a/boilerplates/express-api/skills/test-driven-development/SKILL.md
+++ b/boilerplates/express-api/skills/test-driven-development/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-driven-development
+description: Use when implementing a feature or fixing a bug in this project, to drive the change with a failing test first, then minimal code, then refactor.
+---
+
+# Test-Driven Development
+
+## Overview
+
+Write a failing test before production code. Keep each cycle small and verify
+with the project's test command.
+
+## Process
+
+1. Write one focused test that describes the desired behavior. Run it and watch
+   it fail for the expected reason.
+2. Write the minimal code needed to make the test pass. Run the test suite.
+3. Refactor while keeping the suite green. Do not add behavior without a test.
+4. Repeat for the next small increment.
+
+## Guidelines
+
+- Prefer many small tests over one large test.
+- Test observable behavior (HTTP status, response body), not internals.
+- Run `npm test` after every change; do not claim completion on a red suite.
+- Keep tests deterministic: bind to an ephemeral port and close the server.

--- a/boilerplates/express-api/template/AGENTS.md
+++ b/boilerplates/express-api/template/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this Express.js project.
+
+## Commands
+
+- `npm install` — install dependencies (Express).
+- `npm test` — run HTTP tests (built-in `node:test`; starts the app on an
+  ephemeral port and asserts responses).
+- `npm start` — serve the API on `PORT` (default 3000).
+
+## Conventions
+
+- ES modules (`"type": "module"`).
+- Keep route/handler logic in `src/app.js` (exports `createApp()`), and keep
+  `src/server.js` as a thin entry point so tests can mount the app without a
+  fixed port.
+- Add a test under `test/` for each new route.
+
+## Skills
+
+Curated skills live under `.bwai/skills/` (canonical) and are mirrored into each
+agent's directory. Prefer `express-api-design` and `test-driven-development` for
+those workflows; re-validate skills with `bwai scan-project`.

--- a/boilerplates/express-api/template/CLAUDE.md
+++ b/boilerplates/express-api/template/CLAUDE.md
@@ -1,0 +1,4 @@
+# CLAUDE.md
+
+See [`AGENTS.md`](./AGENTS.md) for the project operating guide. Claude Code reads
+skills from `.claude/skills/`. Run `npm test` to verify changes.

--- a/boilerplates/express-api/template/README.md
+++ b/boilerplates/express-api/template/README.md
@@ -1,0 +1,30 @@
+# express-api
+
+Express.js (ESM) API starter, scaffolded by
+[`boilerplates-with-ai-skills`](https://github.com/johnku2011/boilerplates-with-ai-skills)
+and deployable to Vercel. Ships with AI-agent config and a curated,
+security-vetted skill set.
+
+## Quick start
+
+```bash
+npm install
+npm test        # zero-dependency HTTP tests via node:test
+npm start       # serves http://localhost:3000
+```
+
+Endpoints:
+
+- `GET /` — greeting
+- `GET /api/health` — `{ "status": "ok" }`
+- `POST /api/echo` — echoes the JSON body
+
+## Deploy
+
+`vercel.json` routes all traffic to `src/server.js` via `@vercel/node`.
+
+## AI agent skills
+
+Curated skills (`express-api-design`, `test-driven-development`) were installed
+into `.bwai/skills/` and each agent's directory during scaffolding. Re-validate
+with `bwai scan-project`.

--- a/boilerplates/express-api/template/gitignore
+++ b/boilerplates/express-api/template/gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.vercel/
+dist/
+coverage/
+*.log
+.env
+.env.*
+!.env.example
+.DS_Store

--- a/boilerplates/express-api/template/package.json
+++ b/boilerplates/express-api/template/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "express-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/boilerplates/express-api/template/src/app.js
+++ b/boilerplates/express-api/template/src/app.js
@@ -1,0 +1,27 @@
+import express from "express";
+
+/**
+ * Build the Express application. Exported separately from the server so tests
+ * can mount it without binding a fixed port.
+ * @returns {import("express").Express}
+ */
+export function createApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.get("/", (_req, res) => {
+    res.send("Hello from express-api!");
+  });
+
+  app.get("/api/health", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+
+  app.post("/api/echo", (req, res) => {
+    res.json({ youSent: req.body ?? null });
+  });
+
+  return app;
+}
+
+export default createApp;

--- a/boilerplates/express-api/template/src/server.js
+++ b/boilerplates/express-api/template/src/server.js
@@ -1,0 +1,7 @@
+import { createApp } from "./app.js";
+
+const port = Number.parseInt(process.env.PORT ?? "3000", 10);
+
+createApp().listen(port, () => {
+  console.log(`express-api listening on http://localhost:${port}`);
+});

--- a/boilerplates/express-api/template/test/app.test.js
+++ b/boilerplates/express-api/template/test/app.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../src/app.js";
+
+/**
+ * Start the app on an ephemeral port, run `fn(port)`, then close.
+ * @param {(port: number) => Promise<void>} fn
+ */
+async function withServer(fn) {
+  const server = createApp().listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  try {
+    await fn(port);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test("GET / returns a greeting", async () => {
+  await withServer(async (port) => {
+    const res = await fetch(`http://localhost:${port}/`);
+    assert.equal(res.status, 200);
+    assert.match(await res.text(), /Hello from express-api/);
+  });
+});
+
+test("GET /api/health returns ok", async () => {
+  await withServer(async (port) => {
+    const res = await fetch(`http://localhost:${port}/api/health`);
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { status: "ok" });
+  });
+});
+
+test("POST /api/echo echoes the JSON body", async () => {
+  await withServer(async (port) => {
+    const res = await fetch(`http://localhost:${port}/api/echo`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    });
+    assert.deepEqual(await res.json(), { youSent: { hello: "world" } });
+  });
+});

--- a/boilerplates/express-api/template/vercel.json
+++ b/boilerplates/express-api/template/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [{ "source": "/(.*)", "destination": "/src/server.js" }]
+}

--- a/boilerplates/nextjs-app/boilerplate.json
+++ b/boilerplates/nextjs-app/boilerplate.json
@@ -1,0 +1,8 @@
+{
+  "name": "nextjs-app",
+  "description": "Next.js (App Router) + React + TypeScript starter deployable to Vercel, pre-wired with AI agent config and a curated, security-vetted skill set.",
+  "stack": "nextjs",
+  "version": "0.1.0",
+  "defaultAgents": ["claude", "cursor", "codex", "copilot"],
+  "skills": [{ "name": "nextjs-app-router" }, { "name": "code-review" }]
+}

--- a/boilerplates/nextjs-app/skills/code-review/SKILL.md
+++ b/boilerplates/nextjs-app/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Use when reviewing a diff or pull request in this project, to check correctness, tests, readability, and safety before approving.
+---
+
+# Code Review
+
+## Overview
+
+Give a focused, constructive review of a change. Separate blocking issues from
+optional suggestions.
+
+## Process
+
+1. Read the change description and confirm it matches the diff.
+2. Check correctness: edge cases, error handling, and inputs that could break.
+3. Check tests: is the new behavior covered? Do existing tests still pass?
+4. Check readability: clear names, small functions, no dead code.
+5. Note any security concerns (untrusted input, secrets, unsafe file or process
+   use, leaking server-only data to the client) as blocking.
+
+## Output
+
+- List blocking issues first, each with a concrete fix.
+- Then list non-blocking suggestions.
+- End with an explicit verdict: approve, approve-with-nits, or request-changes.

--- a/boilerplates/nextjs-app/skills/nextjs-app-router/SKILL.md
+++ b/boilerplates/nextjs-app/skills/nextjs-app-router/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: nextjs-app-router
+description: Use when adding pages, layouts, route handlers, or data fetching in this Next.js App Router project, to follow server-first conventions correctly.
+---
+
+# Next.js App Router
+
+## Overview
+
+Build features the App Router way: server components by default, client
+components only when needed, and colocated routes under `app/`.
+
+## Process
+
+1. Add a route by creating `app/<segment>/page.tsx`; add `layout.tsx` for shared
+   UI and `loading.tsx`/`error.tsx` for states.
+2. Keep components as React Server Components unless they need state, effects, or
+   browser APIs. Add `"use client"` only to those leaf components.
+3. Fetch data in server components with `async`/`await`; avoid client-side
+   fetching for initial render when the server can do it.
+4. Put API endpoints in `app/api/<name>/route.ts` using the Web `Request`/
+   `Response` APIs.
+5. Verify with `npm run build` (catches server/client boundary and type errors).
+
+## Guidelines
+
+- Never import server-only modules (fs, secrets, DB clients) into client
+  components.
+- Read secrets from environment variables on the server only; never expose them
+  via `NEXT_PUBLIC_*` unless they are truly public.
+- Keep `page.tsx` thin; move logic into small, typed functions.
+- Prefer `next/link` and `next/image` over raw anchors/images.

--- a/boilerplates/nextjs-app/template/AGENTS.md
+++ b/boilerplates/nextjs-app/template/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this Next.js project.
+
+## Commands
+
+- `npm install` — install dependencies (Next.js, React).
+- `npm run dev` — start the dev server at `http://localhost:3000`.
+- `npm run build` — production build (also the best correctness check).
+- `npm run typecheck` — `tsc --noEmit`.
+
+## Conventions
+
+- App Router under `app/` (React Server Components by default; add
+  `"use client"` only when a component needs browser APIs or state).
+- TypeScript throughout; keep components small and typed.
+- Co-locate route segments and their UI under `app/`.
+
+## Skills
+
+Curated skills live under `.bwai/skills/` (canonical) and are mirrored into each
+agent's directory. Prefer `nextjs-app-router` and `code-review`; re-validate
+skills with `bwai scan-project`.

--- a/boilerplates/nextjs-app/template/CLAUDE.md
+++ b/boilerplates/nextjs-app/template/CLAUDE.md
@@ -1,0 +1,4 @@
+# CLAUDE.md
+
+See [`AGENTS.md`](./AGENTS.md) for the project operating guide. Claude Code reads
+skills from `.claude/skills/`. Run `npm run build` to verify changes.

--- a/boilerplates/nextjs-app/template/README.md
+++ b/boilerplates/nextjs-app/template/README.md
@@ -1,0 +1,21 @@
+# nextjs-app
+
+Next.js (App Router) + React + TypeScript starter, scaffolded by
+[`boilerplates-with-ai-skills`](https://github.com/johnku2011/boilerplates-with-ai-skills)
+and deployable to Vercel. Ships with AI-agent config and a curated,
+security-vetted skill set.
+
+## Quick start
+
+```bash
+npm install
+npm run dev      # http://localhost:3000
+npm run build    # production build
+npm run typecheck
+```
+
+## AI agent skills
+
+Curated skills (`nextjs-app-router`, `code-review`) were installed into
+`.bwai/skills/` and each agent's directory during scaffolding. Re-validate with
+`bwai scan-project`.

--- a/boilerplates/nextjs-app/template/app/layout.tsx
+++ b/boilerplates/nextjs-app/template/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "nextjs-app",
+  description: "Scaffolded by boilerplates-with-ai-skills",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/boilerplates/nextjs-app/template/app/page.tsx
+++ b/boilerplates/nextjs-app/template/app/page.tsx
@@ -1,0 +1,14 @@
+export default function Home() {
+  return (
+    <main style={{ fontFamily: "system-ui, sans-serif", padding: "3rem", maxWidth: 640 }}>
+      <h1>nextjs-app</h1>
+      <p>
+        Scaffolded by <strong>boilerplates-with-ai-skills</strong> and pre-wired with curated,
+        security-vetted AI agent skills.
+      </p>
+      <p>
+        Edit <code>app/page.tsx</code> to get started.
+      </p>
+    </main>
+  );
+}

--- a/boilerplates/nextjs-app/template/gitignore
+++ b/boilerplates/nextjs-app/template/gitignore
@@ -1,0 +1,12 @@
+node_modules/
+/.next/
+/out/
+/build
+.vercel/
+*.log
+.env
+.env.*
+!.env.example
+next-env.d.ts
+*.tsbuildinfo
+.DS_Store

--- a/boilerplates/nextjs-app/template/next.config.mjs
+++ b/boilerplates/nextjs-app/template/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/boilerplates/nextjs-app/template/package.json
+++ b/boilerplates/nextjs-app/template/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "nextjs-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "^15.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
+  }
+}

--- a/boilerplates/nextjs-app/template/tsconfig.json
+++ b/boilerplates/nextjs-app/template/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -1,11 +1,39 @@
 import { describe, it, expect } from "vitest";
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
 import { listBoilerplates, getBoilerplate } from "../src/catalog.js";
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 describe("catalog", () => {
   it("discovers the node-service boilerplate", async () => {
     const all = await listBoilerplates();
     const names = all.map((b) => b.manifest.name);
     expect(names).toContain("node-service");
+  });
+
+  it("includes the Vercel-style boilerplates", async () => {
+    const names = (await listBoilerplates()).map((b) => b.manifest.name);
+    expect(names).toEqual(expect.arrayContaining(["nextjs-app", "express-api", "node-service"]));
+  });
+
+  it("every boilerplate has a template dir and all declared skills on disk", async () => {
+    const all = await listBoilerplates();
+    expect(all.length).toBeGreaterThan(0);
+    for (const b of all) {
+      expect(await exists(b.templateDir), `${b.manifest.name} template`).toBe(true);
+      for (const skill of b.manifest.skills) {
+        const skillMd = join(b.skillsDir, skill.name, "SKILL.md");
+        expect(await exists(skillMd), `${b.manifest.name} skill ${skill.name}`).toBe(true);
+      }
+    }
   });
 
   it("loads a valid manifest with skills", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Uses the existing `bwai` boilerplate framework to add the two flagship Vercel-style starters, each authored as a proper boilerplate (manifest + `template/` + curated, SkillSpector-vetted `skills/`):

- **`nextjs-app`** — Next.js (App Router) + React 19 + TypeScript, deployable to Vercel. Skills: `nextjs-app-router`, `code-review`.
- **`express-api`** — Express.js (ESM) API with zero-dependency `node:test` HTTP tests + `vercel.json`. Skills: `express-api-design`, `test-driven-development`.

Also adds a **catalog integrity test** that validates every boilerplate has a template dir and that all declared skills exist on disk (protects future additions).

## Verification

- ✅ `npm run typecheck` / `npm run build`
- ✅ `npm test` — 20 passed (added catalog checks for the new boilerplates)
- ✅ `bwai list-boilerplates` shows all three
- ✅ **express-api**: `bwai new` → `npm install` → `npm test` (3 pass) → live `curl` (`/`, `/api/health`, `/api/echo`) → `scan-project` gate passes (risk 0)
- ✅ **nextjs-app**: `bwai new` → `npm install` → `next build` succeeds (static pages generated) → `scan-project` gate passes (risk 0) → runs and renders in the browser

[Scaffolded nextjs-app running in the browser](https://cursor.com/agents/bc-a8de4f6a-a148-48fe-943d-747c48349690/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnextjs_app_running.webp)

[vercel_boilerplates_demo.log](https://cursor.com/agents/bc-a8de4f6a-a148-48fe-943d-747c48349690/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvercel_boilerplates_demo.log)

## Notes

Each boilerplate is self-contained (its own `skills/`), matching `requirements.md` §3.1. More templates from the gallery (e.g. a chat/shadcn template, a Slack-agent template) can be added the same way. Skills are duplicated per-boilerplate today; a shared skills library is a possible future framework enhancement.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

