### PR TITLE
Add react-native-app boilerplate (Expo + TypeScript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ for why this project focuses on *bundling starters with vetted skills* and a
 > SkillSpector safety gate wired into CI.
 >
 > Boilerplates: `nextjs-app` (Next.js App Router + React + TS), `express-api`
-> (Express.js on Vercel), and `node-service` (minimal Node ESM).
+> (Express.js on Vercel), `react-native-app` (Expo / React Native + TS), and
+> `node-service` (minimal Node ESM).
 
 ## Install / develop
 

--- a/boilerplates/react-native-app/boilerplate.json
+++ b/boilerplates/react-native-app/boilerplate.json
@@ -1,0 +1,8 @@
+{
+  "name": "react-native-app",
+  "description": "Expo (React Native) + TypeScript mobile starter for iOS, Android, and web, with pure-function tests and a curated, security-vetted skill set for AI agents.",
+  "stack": "react-native-expo",
+  "version": "0.1.0",
+  "defaultAgents": ["claude", "cursor", "codex", "copilot"],
+  "skills": [{ "name": "react-native-development" }, { "name": "test-driven-development" }]
+}

--- a/boilerplates/react-native-app/skills/react-native-development/SKILL.md
+++ b/boilerplates/react-native-app/skills/react-native-development/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: react-native-development
+description: Use when building screens, navigation, styling, or platform behavior in this Expo React Native app, to follow mobile-first conventions and keep logic testable.
+---
+
+# React Native Development (Expo)
+
+## Overview
+
+Build mobile UI with Expo and React Native. Keep screens in components; extract
+testable logic into pure functions under `src/`.
+
+## Process
+
+1. Prefer React Native core components and `StyleSheet.create` before adding UI
+   libraries.
+2. Keep `App.tsx` (or future screens) focused on layout and wiring; move
+   non-trivial logic to pure helpers you can test with `npm test`.
+3. Handle platform differences explicitly (`Platform.OS`, platform-specific
+   files) instead of guessing runtime behavior.
+4. Respect safe areas and accessibility: meaningful labels, tappable targets,
+   sufficient contrast.
+5. Verify with `npm run typecheck` and `npm test` before claiming completion.
+
+## Guidelines
+
+- Do not block the JS thread with heavy sync work; defer or chunk large tasks.
+- Read secrets from environment at build time via Expo config — never hardcode
+  API keys in source.
+- Adding native modules may require an Expo config plugin and a dev client build;
+  document that before adding dependencies.
+- Test on at least one target (iOS simulator, Android emulator, or web) for UI
+  changes; logic-only changes can rely on `npm test`.

--- a/boilerplates/react-native-app/skills/test-driven-development/SKILL.md
+++ b/boilerplates/react-native-app/skills/test-driven-development/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-driven-development
+description: Use when implementing a feature or fixing a bug in this project, to drive the change with a failing test first, then minimal code, then refactor.
+---
+
+# Test-Driven Development
+
+## Overview
+
+Write a failing test before production code. Keep each cycle small and verify
+with the project's test command.
+
+## Process
+
+1. Write one focused test that describes the desired behavior. Run it and watch
+   it fail for the expected reason.
+2. Write the minimal code needed to make the test pass. Run the test suite.
+3. Refactor while keeping the suite green. Do not add behavior without a test.
+4. Repeat for the next small increment.
+
+## Guidelines
+
+- Put pure logic in `src/*.js` and test with `node:test` via `npm test`.
+- For UI, test behavior you can assert without a simulator when possible; use
+  manual verification on a simulator for layout and gestures.
+- Run `npm test` after every logic change; do not claim completion on a red suite.
+- Keep tests deterministic: no wall-clock timing or network in unit tests.

--- a/boilerplates/react-native-app/template/AGENTS.md
+++ b/boilerplates/react-native-app/template/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this Expo / React Native project.
+
+## Commands
+
+- `npm install` — install dependencies (Expo, React Native).
+- `npm test` — run pure-function tests via `node:test` (no simulator needed).
+- `npm run typecheck` — `tsc --noEmit`.
+- `npm start` — Expo dev server (`i` / `a` / `w` for iOS / Android / web).
+
+## Conventions
+
+- TypeScript for UI (`App.tsx`); keep testable logic in small pure modules under
+  `src/` (plain `.js` is fine for helpers that `node:test` imports directly).
+- Use React Native core components (`View`, `Text`, `Pressable`, etc.) and
+  `StyleSheet.create` for styles.
+- Platform-specific code: `Platform.OS` or `.ios.ts` / `.android.ts` suffixes.
+- Do not add native modules without documenting the Expo config plugin requirement.
+
+## Skills
+
+Curated skills live under `.bwai/skills/` (canonical) and are mirrored into each
+agent's directory. Prefer `react-native-development` and
+`test-driven-development`; re-validate skills with `bwai scan-project`.

--- a/boilerplates/react-native-app/template/App.tsx
+++ b/boilerplates/react-native-app/template/App.tsx
@@ -1,0 +1,41 @@
+import { StatusBar } from "expo-status-bar";
+import { StyleSheet, Text, View } from "react-native";
+import { greeting } from "./src/greeting";
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>react-native-app</Text>
+      <Text style={styles.subtitle}>{greeting()}</Text>
+      <Text style={styles.hint}>
+        Scaffolded by boilerplates-with-ai-skills. Edit App.tsx to get started.
+      </Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "700",
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 18,
+    marginBottom: 16,
+  },
+  hint: {
+    fontSize: 14,
+    color: "#666",
+    textAlign: "center",
+    maxWidth: 320,
+  },
+});

--- a/boilerplates/react-native-app/template/CLAUDE.md
+++ b/boilerplates/react-native-app/template/CLAUDE.md
@@ -1,0 +1,4 @@
+# CLAUDE.md
+
+See [`AGENTS.md`](./AGENTS.md) for the project operating guide. Claude Code reads
+skills from `.claude/skills/`. Run `npm test` and `npm run typecheck` to verify changes.

--- a/boilerplates/react-native-app/template/README.md
+++ b/boilerplates/react-native-app/template/README.md
@@ -1,0 +1,35 @@
+# react-native-app
+
+Expo (React Native) + TypeScript mobile starter, scaffolded by
+[`boilerplates-with-ai-skills`](https://github.com/johnku2011/boilerplates-with-ai-skills).
+Targets iOS, Android, and web from one codebase, with AI-agent config and a
+curated, security-vetted skill set.
+
+## Quick start
+
+```bash
+npm install
+npm test           # pure-function tests (node:test; no simulator required)
+npm run typecheck
+npm start          # Expo dev server (scan QR with Expo Go, or press i/a/w)
+```
+
+Platform shortcuts (with simulators/emulators installed):
+
+```bash
+npm run ios
+npm run android
+npm run web
+```
+
+## Project layout
+
+- `App.tsx` — root screen (React Native components).
+- `src/greeting.js` — small pure helper, tested without mounting native UI.
+- `app.json` — Expo config (name, slug, platforms).
+
+## AI agent skills
+
+Curated skills (`react-native-development`, `test-driven-development`) were
+installed into `.bwai/skills/` and each agent's directory during scaffolding.
+Re-validate with `bwai scan-project`.

--- a/boilerplates/react-native-app/template/app.json
+++ b/boilerplates/react-native-app/template/app.json
@@ -1,0 +1,26 @@
+{
+  "expo": {
+    "name": "react-native-app",
+    "slug": "react-native-app",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "platforms": ["ios", "android", "web"],
+    "userInterfaceStyle": "automatic",
+    "newArchEnabled": true,
+    "splash": {
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "backgroundColor": "#ffffff"
+      }
+    },
+    "web": {
+      "bundler": "metro"
+    }
+  }
+}

--- a/boilerplates/react-native-app/template/babel.config.js
+++ b/boilerplates/react-native-app/template/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+  };
+};

--- a/boilerplates/react-native-app/template/gitignore
+++ b/boilerplates/react-native-app/template/gitignore
@@ -1,0 +1,15 @@
+node_modules/
+.expo/
+dist/
+web-build/
+*.log
+.env
+.env.*
+!.env.example
+.DS_Store
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+*.orig.*

--- a/boilerplates/react-native-app/template/package.json
+++ b/boilerplates/react-native-app/template/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-native-app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "test": "node --test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "expo": "~52.0.0",
+    "expo-status-bar": "~2.0.0",
+    "react": "18.3.1",
+    "react-native": "0.76.5"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.0",
+    "@types/react": "~18.3.0",
+    "babel-preset-expo": "~12.0.0",
+    "typescript": "~5.6.0"
+  }
+}

--- a/boilerplates/react-native-app/template/src/greeting.js
+++ b/boilerplates/react-native-app/template/src/greeting.js
@@ -1,0 +1,9 @@
+/**
+ * Pure greeting helper — unit tested with node:test (no native test runner required).
+ * @param {string | undefined} [name]
+ * @returns {string}
+ */
+export function greeting(name) {
+  const trimmed = (name ?? "").trim();
+  return `Hello, ${trimmed.length > 0 ? trimmed : "world"}!`;
+}

--- a/boilerplates/react-native-app/template/test/greeting.test.js
+++ b/boilerplates/react-native-app/template/test/greeting.test.js
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { greeting } from "../src/greeting.js";
+
+test("greets a provided name", () => {
+  assert.equal(greeting("Ada"), "Hello, Ada!");
+});
+
+test("falls back to world when empty", () => {
+  assert.equal(greeting(""), "Hello, world!");
+  assert.equal(greeting(undefined), "Hello, world!");
+});

--- a/boilerplates/react-native-app/template/tsconfig.json
+++ b/boilerplates/react-native-app/template/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "allowJs": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
+}

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -21,7 +21,9 @@ describe("catalog", () => {
 
   it("includes the Vercel-style boilerplates", async () => {
     const names = (await listBoilerplates()).map((b) => b.manifest.name);
-    expect(names).toEqual(expect.arrayContaining(["nextjs-app", "express-api", "node-service"]));
+    expect(names).toEqual(
+      expect.arrayContaining(["nextjs-app", "express-api", "node-service", "react-native-app"]),
+    );
   });
 
   it("every boilerplate has a template dir and all declared skills on disk", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds **`react-native-app`** — an Expo (React Native) + TypeScript mobile starter for iOS, Android, and web, authored with the same `bwai` boilerplate framework as the Vercel-style templates.

- **Stack:** Expo SDK 52, React Native 0.76, React 18.3
- **Skills:** `react-native-development`, `test-driven-development`
- **Template:** `App.tsx` root screen, `src/greeting.js` (pure helper), `app.json`, `babel.config.js`, `tsconfig.json`
- **Tests:** zero-simulator `node:test` on pure logic; `npm run typecheck` for TS

## Verification

- ✅ `npm test` — 20 passed (catalog includes `react-native-app`)
- ✅ `bwai new react-native-app` → skills wired → `npm install` → `npm test` (2 pass) → `npm run typecheck` clean
- ✅ `bwai scan-project` — both skills risk 0 (SkillSpector gate passes)

## Usage

```bash
bwai new react-native-app ./my-app --agents claude,cursor
cd my-app && npm install && npm start
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

