### PR TITLE
Phase 2A: catalog scan, SARIF reports, CI trust gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,16 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v5
       - run: npm ci
       - run: npm run build
-      # Install the NVIDIA SkillSpector security scanner for the gate.
-      - run: pip install skillspector || echo "skillspector install failed; gate will report scanner unavailable"
-      # Scaffold a throwaway project and run the safety gate over its skills.
-      - run: |
+      - name: Install SkillSpector
+        run: uv tool install git+https://github.com/NVIDIA/skillspector.git
+      - name: Add uv tools to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Scan catalog skills
+        run: node dist/cli.js scan-catalog --threshold 30 --require-scanner
+      - name: Scaffold and scan a demo project
+        run: |
           node dist/cli.js new node-service /tmp/ci-demo --agents claude
-          node dist/cli.js scan-project /tmp/ci-demo --threshold 50
+          node dist/cli.js scan-project /tmp/ci-demo --threshold 50 --require-scanner

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,17 +29,18 @@ CLI smoke checks:
 ```bash
 node dist/cli.js list-boilerplates
 node dist/cli.js new node-service /tmp/demo --agents claude
+node dist/cli.js scan-catalog --threshold 30 --require-scanner
 node dist/cli.js scan-project /tmp/demo --threshold 50
 node dist/cli.js search-skills testing --limit 5
 ```
 
 ## Layout
 
-- `src/` — `bwai` CLI (`list-boilerplates`, `new`, `scan-project`, `search-skills`)
+- `src/` — `bwai` CLI (`list-boilerplates`, `new`, `scan-catalog`, `scan-project`, `search-skills`)
 - `shared/skills/` — catalog-wide skills (`source: "shared"` in manifests)
 - `boilerplates/` — catalog (`<name>/boilerplate.json`, `template/`, local `skills/`)
 - `tests/` — vitest unit/integration tests
-- `.github/workflows/ci.yml` — build/test + SkillSpector safety-gate job
+- `.github/workflows/ci.yml` — build/test + catalog scan + SkillSpector safety-gate job
 
 `bwai new` resolves `local` + `shared` skills into one `.bwai/skills/` bundle in the
 generated project; end users only pick a boilerplate name.
@@ -54,6 +55,6 @@ generated project; end users only pick a boilerplate name.
 ## Cursor Cloud specific instructions
 
 - **Update script:** `npm ci` (or `npm install` if no lockfile) — see Cloud VM startup config.
-- **SkillSpector (optional locally):** `uv tool install git+https://github.com/NVIDIA/skillspector.git` — not on PyPI as `skillspector`. CI installs via git; without it, `scan-project` records skills as `skipped` unless `--require-scanner`.
+- **SkillSpector (optional locally):** `uv tool install git+https://github.com/NVIDIA/skillspector.git` — not on PyPI as `skillspector`. CI runs `scan-catalog --require-scanner` and `scan-project --require-scanner`; without SkillSpector locally, scans record skills as `skipped` unless `--require-scanner`.
 - **Boilerplate template tests** under `boilerplates/**/template/` use `node:test`, not vitest — excluded in `vitest.config.ts`.
 - Do not merge stale branches `cursor/document-spec-only-env-9690` or `cursor/landscape-and-differentiation-9690`; their PRs predate the full implementation (PR #2 content is already on `main`).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 boilerplates-with-ai-skills contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ See [`requirements.md`](./requirements.md) for the full spec and
 for why this project focuses on *bundling starters with vetted skills* and a
 *security gate* rather than reinventing skill formats, installers, or directories.
 
-> Status: Phase 1 foundation — the `bwai` CLI (`list-boilerplates`, `new`,
-> `search-skills`, `scan-project`), a `skills.lock` provenance file, and a
+> Status: Phase 2A — catalog scan + SARIF reports in CI. See [`ROADMAP.md`](./ROADMAP.md)
+> for Phase 2B (promotion loop) and beyond. The `bwai` CLI (`list-boilerplates`, `new`,
+> `scan-catalog`, `search-skills`, `scan-project`), a `skills.lock` provenance file, and a
 > SkillSpector safety gate wired into CI.
 >
 > Boilerplates: `nextjs-app` (Next.js App Router + React + TS), `express-api`
@@ -40,6 +41,9 @@ bwai new node-service ./my-app --agents claude,cursor
 
 # Run the SkillSpector safety gate over the project's skills
 bwai scan-project ./my-app --threshold 50
+
+# Scan all skills shipped in this repo (shared + boilerplate-local)
+bwai scan-catalog --threshold 30 --require-scanner
 
 # Discover recently-updated skills from public hubs (GitHub + SkillsMP)
 bwai search-skills testing --limit 10
@@ -72,7 +76,7 @@ promoting any into a boilerplate. Use `--source github|skillsmp|all` and
 
 `bwai scan-project` runs the [NVIDIA SkillSpector](https://github.com/NVIDIA/SkillSpector)
 scanner over each installed skill, records the risk score in `skills.lock`,
-writes reports to `safety-reports/`, and **fails (exit 1) when any skill exceeds
+writes reports to `safety-reports/` (JSON + SARIF when the scanner supports it), and **fails (exit 1) when any skill exceeds
 the risk threshold**.
 
 - Install the scanner: `uv tool install git+https://github.com/NVIDIA/skillspector.git`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,63 @@
+# Roadmap
+
+This document tracks what ships after each phase. **Phase 2A is in progress on this branch.**
+
+## Phase 2A — Trust & CI (current)
+
+Goal: make the security gate real in CI and match the spec’s reporting shape.
+
+| Item | Status |
+| --- | --- |
+| Fix SkillSpector install in CI (`uv tool install` from GitHub, not PyPI) | Done on branch |
+| `bwai scan-catalog` — scan `shared/skills/` + `boilerplates/*/skills/` | Done on branch |
+| SARIF output in `scan-project` and catalog scans (`safety-reports/*.sarif`) | Done on branch |
+| Stricter catalog threshold in CI (default 30) | Done on branch |
+| `LICENSE` (MIT) | Done on branch |
+
+## Phase 2B — Discovery & promotion (next)
+
+Goal: close the loop from `search-skills` to curated catalog skills.
+
+| Item | Notes |
+| --- | --- |
+| `registry/skills-index.json` | Machine-readable index of promoted skills + metadata |
+| Daily GitHub Action | Run `bwai search-skills --scan N`, open issues or PRs for high-signal candidates |
+| `bwai promote <skill>` | Copy vetted skill into `shared/skills/` or a boilerplate with provenance |
+| `bwai sync-skills` | Refresh shared skills across boilerplates from lock/index |
+| `project-security` shared skill | Security review skill bundled with every boilerplate |
+
+## Phase 2C — Depth & upstream (next’s next)
+
+Goal: richer agent guidance and upstream alignment.
+
+| Item | Notes |
+| --- | --- |
+| Superpowers upstream | Align with [obra/superpowers](https://github.com/obra/superpowers) workflows where applicable |
+| Deepen thin skills | Expand shared skills beyond ~30-line stubs |
+| `deploy-vercel` shared skill | Deployment guidance for Next/Express boilerplates |
+| Baseline SARIF in repo | Optional committed `safety-reports/catalog/` from real scans |
+
+## Phase 2D — Distribution & community
+
+| Item | Notes |
+| --- | --- |
+| npm publish `bwai` | Public CLI on npm |
+| More boilerplates | e.g. Fastify, Remix, Python service |
+| `CONTRIBUTING.md` | Promotion criteria, scan thresholds, skill authoring |
+| Close stale PRs | #1 (spec-only AGENTS), #2 (landscape — already on main) |
+
+## Commands reference (today)
+
+```bash
+bwai list-boilerplates
+bwai new <boilerplate> [dir] --agents claude,cursor
+bwai scan-catalog --threshold 30 --require-scanner
+bwai scan-project [dir] --threshold 50 --require-scanner
+bwai search-skills [query] --source all --scan 5
+```
+
+SkillSpector install:
+
+```bash
+uv tool install git+https://github.com/NVIDIA/skillspector.git
+```

--- a/safety-reports/catalog/express-api-express-api-design.json
+++ b/safety-reports/catalog/express-api-express-api-design.json
@@ -1,0 +1,8 @@
+{
+  "skill": "boilerplate/express-api/express-api-design",
+  "threshold": 30,
+  "riskScore": 0,
+  "scanMode": "static",
+  "findings": 0,
+  "sarif": "{\n  \"version\": \"2.1.0\",\n  \"$schema\": \"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json\",\n  \"runs\": [\n    {\n      \"tool\": {\n        \"driver\": {\n          \"name\": \"skillspector\",\n          \"version\": \"2.3.9\"\n        }\n      },\n      \"results\": []\n    }\n  ]\n}"
+}

--- a/safety-reports/catalog/express-api-express-api-design.sarif
+++ b/safety-reports/catalog/express-api-express-api-design.sarif
@@ -1,0 +1,15 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "skillspector",
+          "version": "2.3.9"
+        }
+      },
+      "results": []
+    }
+  ]
+}

--- a/safety-reports/catalog/nextjs-app-nextjs-app-router.json
+++ b/safety-reports/catalog/nextjs-app-nextjs-app-router.json
@@ -1,0 +1,8 @@
+{
+  "skill": "boilerplate/nextjs-app/nextjs-app-router",
+  "threshold": 30,
+  "riskScore": 0,
+  "scanMode": "static",
+  "findings": 0,
+  "sarif": "{\n  \"version\": \"2.1.0\",\n  \"$schema\": \"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json\",\n  \"runs\": [\n    {\n      \"tool\": {\n        \"driver\": {\n          \"name\": \"skillspector\",\n          \"version\": \"2.3.9\"\n        }\n      },\n      \"results\": []\n    }\n  ]\n}"
+}

--- a/safety-reports/catalog/nextjs-app-nextjs-app-router.sarif
+++ b/safety-reports/catalog/nextjs-app-nextjs-app-router.sarif
@@ -1,0 +1,15 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "skillspector",
+          "version": "2.3.9"
+        }
+      },
+      "results": []
+    }
+  ]
+}

--- a/safety-reports/catalog/react-native-app-react-native-development.json
+++ b/safety-reports/catalog/react-native-app-react-native-development.json
@@ -1,0 +1,8 @@
+{
+  "skill": "boilerplate/react-native-app/react-native-development",
+  "threshold": 30,
+  "riskScore": 0,
+  "scanMode": "static",
+  "findings": 0,
+  "sarif": "{\n  \"version\": \"2.1.0\",\n  \"$schema\": \"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json\",\n  \"runs\": [\n    {\n      \"tool\": {\n        \"driver\": {\n          \"name\": \"skillspector\",\n          \"version\": \"2.3.9\"\n        }\n      },\n      \"results\": []\n    }\n  ]\n}"
+}

--- a/safety-reports/catalog/react-native-app-react-native-development.sarif
+++ b/safety-reports/catalog/react-native-app-react-native-development.sarif
@@ -1,0 +1,15 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "skillspector",
+          "version": "2.3.9"
+        }
+      },
+      "results": []
+    }
+  ]
+}

--- a/safety-reports/catalog/shared-code-review.json
+++ b/safety-reports/catalog/shared-code-review.json
@@ -1,0 +1,8 @@
+{
+  "skill": "shared/code-review",
+  "threshold": 30,
+  "riskScore": 7,
+  "scanMode": "static",
+  "findings": 1,
+  "sarif": "{\n  \"version\": \"2.1.0\",\n  \"$schema\": \"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json\",\n  \"runs\": [\n    {\n      \"tool\": {\n        \"driver\": {\n          \"name\": \"skillspector\",\n          \"version\": \"2.3.9\",\n          \"rules\": [\n            {\n              \"id\": \"EA2\",\n              \"shortDescription\": {\n                \"text\": \"Autonomous Decision Making\"\n              }\n            }\n          ]\n        }\n      },\n      \"results\": [\n        {\n          \"ruleId\": \"EA2\",\n          \"message\": {\n            \"text\": \"Autonomous Decision Making\"\n          },\n          \"level\": \"warning\",\n          \"locations\": [\n            {\n              \"physicalLocation\": {\n                \"artifactLocation\": {\n                  \"uri\": \"SKILL.md\"\n                },\n                \"region\": {\n                  \"startLine\": 30\n                }\n              }\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
+}

--- a/safety-reports/catalog/shared-code-review.sarif
+++ b/safety-reports/catalog/shared-code-review.sarif
@@ -1,0 +1,43 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "skillspector",
+          "version": "2.3.9",
+          "rules": [
+            {
+              "id": "EA2",
+              "shortDescription": {
+                "text": "Autonomous Decision Making"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "EA2",
+          "message": {
+            "text": "Autonomous Decision Making"
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "SKILL.md"
+                },
+                "region": {
+                  "startLine": 30
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/safety-reports/catalog/shared-test-driven-development.json
+++ b/safety-reports/catalog/shared-test-driven-development.json
@@ -1,0 +1,8 @@
+{
+  "skill": "shared/test-driven-development",
+  "threshold": 30,
+  "riskScore": 0,
+  "scanMode": "static",
+  "findings": 0,
+  "sarif": "{\n  \"version\": \"2.1.0\",\n  \"$schema\": \"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json\",\n  \"runs\": [\n    {\n      \"tool\": {\n        \"driver\": {\n          \"name\": \"skillspector\",\n          \"version\": \"2.3.9\"\n        }\n      },\n      \"results\": []\n    }\n  ]\n}"
+}

--- a/safety-reports/catalog/shared-test-driven-development.sarif
+++ b/safety-reports/catalog/shared-test-driven-development.sarif
@@ -1,0 +1,15 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.4.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "skillspector",
+          "version": "2.3.9"
+        }
+      },
+      "results": []
+    }
+  ]
+}

--- a/safety-reports/catalog/summary.md
+++ b/safety-reports/catalog/summary.md
@@ -1,0 +1,14 @@
+# Catalog Safety Report
+
+- Scanner available: yes
+- Threshold: risk score must be <= 30
+- Generated: 2026-07-05T02:45:47.002Z
+
+| Skill | Status | Risk score | Findings |
+| --- | --- | --- | --- |
+| shared/code-review | passed | 7 | 1 |
+| shared/test-driven-development | passed | 0 | 0 |
+| boilerplate/express-api/express-api-design | passed | 0 | 0 |
+| boilerplate/nextjs-app/nextjs-app-router | passed | 0 | 0 |
+| boilerplate/react-native-app/react-native-development | passed | 0 | 0 |
+

--- a/src/catalog-scan.ts
+++ b/src/catalog-scan.ts
@@ -1,0 +1,185 @@
+import { readdir, stat, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { listBoilerplates } from "./catalog.js";
+import { defaultBoilerplatesDir, defaultSharedSkillsDir, packageRoot } from "./paths.js";
+import { scanSkillDirectory, type SkillScanner, type ScanResult } from "./scan.js";
+
+export interface CatalogSkillTarget {
+  id: string;
+  label: string;
+  dir: string;
+}
+
+export interface CatalogScanResult {
+  name: string;
+  id: string;
+  riskScore: number | null;
+  status: "passed" | "failed" | "skipped";
+  findings: number;
+}
+
+export interface CatalogScanReport {
+  passed: boolean;
+  scannerAvailable: boolean;
+  threshold: number;
+  reportsDir: string;
+  results: CatalogScanResult[];
+}
+
+async function isSkillDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory() && (await stat(join(path, "SKILL.md"))).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Discover every skill directory shipped in this catalog repo. */
+export async function listCatalogSkillTargets(
+  opts: { boilerplatesDir?: string; sharedSkillsDir?: string } = {},
+): Promise<CatalogSkillTarget[]> {
+  const sharedDir = opts.sharedSkillsDir ?? defaultSharedSkillsDir();
+  const boilerplatesDir = opts.boilerplatesDir ?? defaultBoilerplatesDir();
+  const targets: CatalogSkillTarget[] = [];
+
+  try {
+    for (const name of (await readdir(sharedDir)).sort()) {
+      const dir = join(sharedDir, name);
+      if (await isSkillDirectory(dir)) {
+        targets.push({ id: `shared-${name}`, label: `shared/${name}`, dir });
+      }
+    }
+  } catch {
+    // no shared dir
+  }
+
+  for (const bp of await listBoilerplates(boilerplatesDir)) {
+    let entries: string[] = [];
+    try {
+      entries = await readdir(bp.skillsDir);
+    } catch {
+      continue;
+    }
+    for (const name of entries.sort()) {
+      const dir = join(bp.skillsDir, name);
+      if (await isSkillDirectory(dir)) {
+        targets.push({
+          id: `${bp.manifest.name}-${name}`,
+          label: `boilerplate/${bp.manifest.name}/${name}`,
+          dir,
+        });
+      }
+    }
+  }
+
+  return targets;
+}
+
+function safeReportBasename(id: string): string {
+  return id.replace(/[^a-zA-Z0-9._-]+/g, "-");
+}
+
+export interface ScanCatalogOptions {
+  scanner: SkillScanner;
+  threshold?: number;
+  useLlm?: boolean;
+  requireScanner?: boolean;
+  reportsDir?: string;
+  boilerplatesDir?: string;
+  sharedSkillsDir?: string;
+}
+
+export async function scanCatalog(options: ScanCatalogOptions): Promise<CatalogScanReport> {
+  const threshold = options.threshold ?? 30;
+  const useLlm = options.useLlm ?? false;
+  const requireScanner = options.requireScanner ?? false;
+  const reportsDir = options.reportsDir ?? join(packageRoot(), "safety-reports", "catalog");
+  const targets = await listCatalogSkillTargets(options);
+
+  await mkdir(reportsDir, { recursive: true });
+
+  const available = await options.scanner.isAvailable();
+  if (!available && requireScanner) {
+    throw new Error(
+      `Security scanner "${options.scanner.name}" is not installed, but --require-scanner was set. ` +
+        `Install with: uv tool install git+https://github.com/NVIDIA/skillspector.git`,
+    );
+  }
+
+  const results: CatalogScanResult[] = [];
+  let passed = true;
+
+  if (!available) {
+    for (const target of targets) {
+      results.push({
+        name: target.label,
+        id: target.id,
+        riskScore: null,
+        status: "skipped",
+        findings: 0,
+      });
+    }
+    await writeCatalogSummary(reportsDir, { threshold, scannerAvailable: false, results });
+    return { passed: true, scannerAvailable: false, threshold, reportsDir, results };
+  }
+
+  for (const target of targets) {
+    const scan = await scanSkillDirectory(options.scanner, target.dir, { useLlm });
+    const status = scan.riskScore > threshold ? "failed" : "passed";
+    if (status === "failed") passed = false;
+
+    results.push({
+      name: target.label,
+      id: target.id,
+      riskScore: scan.riskScore,
+      status,
+      findings: scan.findings,
+    });
+
+    const base = safeReportBasename(target.id);
+    await writeFile(
+      join(reportsDir, `${base}.json`),
+      `${JSON.stringify({ skill: target.label, threshold, ...scan }, null, 2)}\n`,
+      "utf8",
+    );
+    if (scan.sarif) {
+      await writeFile(join(reportsDir, `${base}.sarif`), `${scan.sarif}\n`, "utf8");
+    }
+  }
+
+  await writeCatalogSummary(reportsDir, { threshold, scannerAvailable: true, results });
+  return { passed, scannerAvailable: true, threshold, reportsDir, results };
+}
+
+async function writeCatalogSummary(
+  reportsDir: string,
+  summary: {
+    threshold: number;
+    scannerAvailable: boolean;
+    results: CatalogScanResult[];
+  },
+): Promise<void> {
+  const lines: string[] = [
+    "# Catalog Safety Report",
+    "",
+    `- Scanner available: ${summary.scannerAvailable ? "yes" : "no"}`,
+    `- Threshold: risk score must be <= ${summary.threshold}`,
+    `- Generated: ${new Date().toISOString()}`,
+    "",
+    "| Skill | Status | Risk score | Findings |",
+    "| --- | --- | --- | --- |",
+  ];
+  for (const r of summary.results) {
+    lines.push(`| ${r.name} | ${r.status} | ${r.riskScore ?? "n/a"} | ${r.findings ?? "n/a"} |`);
+  }
+  lines.push("");
+  if (!summary.scannerAvailable) {
+    lines.push(
+      "> SkillSpector was not found on PATH. Install with " +
+        "`uv tool install git+https://github.com/NVIDIA/skillspector.git`.",
+    );
+  }
+  await writeFile(join(reportsDir, "summary.md"), `${lines.join("\n")}\n`, "utf8");
+}
+
+export type { ScanResult };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { listBoilerplates } from "./catalog.js";
 import { scaffold } from "./scaffold.js";
 import { parseAgents, type AgentId } from "./agents.js";
+import { scanCatalog } from "./catalog-scan.js";
 import { scanProject, SkillSpectorScanner } from "./scan.js";
 import { getBoilerplate } from "./catalog.js";
 import {
@@ -72,6 +73,30 @@ program
   });
 
 program
+  .command("scan-catalog")
+  .description("Scan all shared and boilerplate-local skills in the repo catalog")
+  .option("--threshold <n>", "Maximum acceptable risk score", "30")
+  .option("--require-scanner", "Fail if SkillSpector is not installed", false)
+  .option("--llm", "Enable LLM-assisted scanning when supported", false)
+  .action(async (options: { threshold: string; requireScanner?: boolean; llm?: boolean }) => {
+    try {
+      const result = await scanCatalog({
+        scanner: new SkillSpectorScanner(),
+        threshold: Number(options.threshold),
+        requireScanner: Boolean(options.requireScanner),
+        useLlm: Boolean(options.llm),
+      });
+      console.log(`Catalog scan complete. Reports: ${result.reportsDir}`);
+      console.log(`Skills scanned: ${result.results.length}`);
+      console.log(`Passed: ${result.passed ? "yes" : "no"}`);
+      if (!result.passed) process.exitCode = 1;
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    }
+  });
+
+program
   .command("scan-project")
   .alias("scan")
   .argument("[dir]", "project directory to scan", ".")
@@ -98,7 +123,7 @@ program
       if (!report.scannerAvailable) {
         console.log(
           "SkillSpector not found on PATH; skills were recorded as 'skipped'. " +
-            "Install with `pip install skillspector` for a real scan.",
+            "Install with `uv tool install git+https://github.com/NVIDIA/skillspector.git`.",
         );
       }
       for (const r of report.results) {

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -8,6 +8,7 @@ export interface ScanResult {
   riskScore: number;
   scanMode: "static" | "llm";
   findings: number;
+  sarif?: string;
 }
 
 export interface SkillScanner {
@@ -21,6 +22,8 @@ interface CommandResult {
   stdout: string;
   stderr: string;
 }
+
+const SKILLSPECTOR_INSTALL = "uv tool install git+https://github.com/NVIDIA/skillspector.git";
 
 function runCommand(command: string, args: string[]): Promise<CommandResult> {
   return new Promise((resolve) => {
@@ -40,6 +43,18 @@ function runCommand(command: string, args: string[]): Promise<CommandResult> {
   });
 }
 
+function parseSarifOutput(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{")) return undefined;
+  try {
+    const parsed = JSON.parse(trimmed) as { version?: string };
+    if (parsed.version?.startsWith("2.")) return trimmed;
+  } catch {
+    // not SARIF JSON
+  }
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 /** Adapter around the NVIDIA SkillSpector CLI (`skillspector`). */
 export class SkillSpectorScanner implements SkillScanner {
   readonly name = "skillspector";
@@ -54,12 +69,29 @@ export class SkillSpectorScanner implements SkillScanner {
     if (!opts.useLlm) args.push("--no-llm");
     const { stdout } = await runCommand("skillspector", args);
     const parsed = extractJson(stdout);
-    return {
+    const result: ScanResult = {
       riskScore: readRiskScore(parsed),
       scanMode: readLlmUsed(parsed) ? "llm" : "static",
       findings: readFindings(parsed),
     };
+
+    const sarifArgs = ["scan", skillDir, "--format", "sarif"];
+    if (!opts.useLlm) sarifArgs.push("--no-llm");
+    const { stdout: sarifStdout } = await runCommand("skillspector", sarifArgs);
+    const sarif = parseSarifOutput(sarifStdout);
+    if (sarif) result.sarif = sarif;
+
+    return result;
   }
+}
+
+/** Scan one skill directory with the provided scanner (used by catalog scan). */
+export async function scanSkillDirectory(
+  scanner: SkillScanner,
+  skillDir: string,
+  opts: { useLlm: boolean },
+): Promise<ScanResult> {
+  return scanner.scan(skillDir, opts);
 }
 
 /**
@@ -151,7 +183,7 @@ export async function scanProject(options: ScanProjectOptions): Promise<ScanProj
     if (requireScanner) {
       throw new Error(
         `Security scanner "${scanner.name}" is not installed, but --require-scanner was set. ` +
-          `Install it (e.g. pip install skillspector) and retry.`,
+          `Install with: ${SKILLSPECTOR_INSTALL}`,
       );
     }
     for (const skill of lock.skills) {
@@ -186,9 +218,12 @@ export async function scanProject(options: ScanProjectOptions): Promise<ScanProj
 
     await writeFile(
       join(reportsDir, `${skill.name}.json`),
-      `${JSON.stringify({ skill: skill.name, threshold, ...result }, null, 2)}\n`,
+      `${JSON.stringify({ skill: skill.name, threshold, ...result, sarif: undefined }, null, 2)}\n`,
       "utf8",
     );
+    if (result.sarif) {
+      await writeFile(join(reportsDir, `${skill.name}.sarif`), `${result.sarif}\n`, "utf8");
+    }
   }
 
   await persist(projectDir, lock, reportsDir, {
@@ -227,7 +262,7 @@ async function persist(
   if (!summary.scannerAvailable) {
     lines.push(
       "> SkillSpector was not found on PATH, so skills were not scanned. " +
-        "Install it with `pip install skillspector` and re-run `bwai scan-project`, " +
+        `Install it with \`${SKILLSPECTOR_INSTALL}\` and re-run \`bwai scan-project\`, ` +
         "or pass `--require-scanner` to make a missing scanner fail the gate.",
     );
   }

--- a/tests/catalog-scan.test.ts
+++ b/tests/catalog-scan.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listCatalogSkillTargets, scanCatalog } from "../src/catalog-scan.js";
+import type { SkillScanner } from "../src/scan.js";
+
+function fakeScanner(opts: {
+  available: boolean;
+  riskByLabel?: Record<string, number>;
+  sarif?: string;
+}): SkillScanner {
+  return {
+    name: "fake",
+    async isAvailable() {
+      return opts.available;
+    },
+    async scan(skillDir) {
+      const name = skillDir.split("/").pop() ?? "";
+      const riskScore = opts.riskByLabel?.[name] ?? 0;
+      return {
+        riskScore,
+        scanMode: "static",
+        findings: riskScore > 0 ? 1 : 0,
+        sarif: opts.sarif,
+      };
+    },
+  };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("catalog scan", () => {
+  it("discovers shared and local catalog skills", async () => {
+    const targets = await listCatalogSkillTargets();
+    const labels = targets.map((t) => t.label);
+    expect(labels).toEqual(
+      expect.arrayContaining(["shared/code-review", "shared/test-driven-development"]),
+    );
+    expect(labels.some((l) => l.startsWith("boilerplate/"))).toBe(true);
+  });
+
+  describe("scanCatalog", () => {
+    let reportsDir: string;
+
+    beforeEach(async () => {
+      reportsDir = await mkdtemp(join(tmpdir(), "bwai-catalog-scan-"));
+    });
+
+    afterEach(async () => {
+      await rm(reportsDir, { recursive: true, force: true });
+    });
+
+    it("passes when all skills are below threshold and writes SARIF", async () => {
+      const sarif = JSON.stringify({ version: "2.1.0", runs: [] });
+      const report = await scanCatalog({
+        scanner: fakeScanner({ available: true, riskByLabel: {}, sarif }),
+        threshold: 30,
+        reportsDir,
+      });
+      expect(report.passed).toBe(true);
+      expect(report.scannerAvailable).toBe(true);
+      expect(report.results.length).toBeGreaterThan(0);
+      expect(await exists(join(reportsDir, "summary.md"))).toBe(true);
+
+      const first = report.results[0]!;
+      const base = first.id.replace(/[^a-zA-Z0-9._-]+/g, "-");
+      expect(await exists(join(reportsDir, `${base}.json`))).toBe(true);
+      expect(await exists(join(reportsDir, `${base}.sarif`))).toBe(true);
+      const written = await readFile(join(reportsDir, `${base}.sarif`), "utf8");
+      expect(written).toContain("2.1.0");
+    });
+
+    it("fails when a skill exceeds threshold", async () => {
+      const report = await scanCatalog({
+        scanner: fakeScanner({
+          available: true,
+          riskByLabel: { "code-review": 99 },
+        }),
+        threshold: 30,
+        reportsDir,
+      });
+      expect(report.passed).toBe(false);
+      const failed = report.results.find((r) => r.name.includes("code-review"));
+      expect(failed?.status).toBe("failed");
+    });
+
+    it("throws when scanner unavailable and requireScanner is set", async () => {
+      await expect(
+        scanCatalog({
+          scanner: fakeScanner({ available: false }),
+          requireScanner: true,
+          reportsDir,
+        }),
+      ).rejects.toThrow(/not installed/);
+    });
+  });
+});

--- a/tests/scan.test.ts
+++ b/tests/scan.test.ts
@@ -18,7 +18,12 @@ function fakeScanner(opts: {
     async scan(skillDir) {
       const name = skillDir.split("/").pop() ?? "";
       const riskScore = opts.riskByName?.[name] ?? 0;
-      return { riskScore, scanMode: "static", findings: riskScore > 0 ? 1 : 0 };
+      return {
+        riskScore,
+        scanMode: "static",
+        findings: riskScore > 0 ? 1 : 0,
+        sarif: JSON.stringify({ version: "2.1.0", runs: [{ tool: { driver: { name: "fake" } } }] }),
+      };
     },
   };
 }
@@ -56,6 +61,7 @@ describe("scanProject", () => {
     expect(report.scannerAvailable).toBe(true);
     expect(await exists(join(project, "safety-reports", "summary.md"))).toBe(true);
     expect(await exists(join(project, "safety-reports", "code-review.json"))).toBe(true);
+    expect(await exists(join(project, "safety-reports", "code-review.sarif"))).toBe(true);
 
     const lock = await readLock(project);
     const cr = lock.skills.find((s) => s.name === "code-review");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 2A (Trust & CI)** from the roadmap.

- **`bwai scan-catalog`** — scans all `shared/skills/` and `boilerplates/*/skills/` with configurable threshold (default 30)
- **SARIF output** — `scan-project` and catalog scans write `*.sarif` alongside JSON under `safety-reports/`
- **CI fix** — installs SkillSpector via `uv tool install git+https://github.com/NVIDIA/skillspector.git` (not PyPI); runs `scan-catalog --require-scanner` and scaffold + `scan-project --require-scanner`
- **LICENSE** (MIT) and **ROADMAP.md** tracking Phase 2B (promotion loop), 2C (depth/upstream), 2D (distribution)
- Committed baseline **`safety-reports/catalog/`** from a real SkillSpector run (5 skills, all passed at threshold 30)

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (29 tests)
- [x] `node dist/cli.js scan-catalog --threshold 30 --require-scanner` (real SkillSpector)

## What's next (Phase 2B)

See `ROADMAP.md`: `registry/skills-index.json`, daily discovery workflow, `bwai promote`, `bwai sync-skills`, `project-security` shared skill.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

