### PR TITLE
Publish as bwai-cli — simpler npm name than scoped @johnku2011/bwai

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
-      - name: Publish bwai
+      - name: Publish @johnku2011/bwai
         run: npm publish --access public --tag "${{ github.event.inputs.tag || 'latest' }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
-      - name: Publish @johnku2011/bwai
+      - name: Publish bwai-cli
         run: npm publish --access public --tag "${{ github.event.inputs.tag || 'latest' }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ runnable project plus a curated `SKILL.md` skill set wired for Claude, Cursor,
 Codex, and Copilot, with NVIDIA SkillSpector gating and a `skills.lock`
 provenance file.
 
-Contributing: see [`CONTRIBUTING.md`](./CONTRIBUTING.md). Published on npm as **`bwai`** (`npx bwai`). Landing page: [`site/`](../site/) → GitHub Pages.
+Contributing: see [`CONTRIBUTING.md`](./CONTRIBUTING.md). Published on npm as **`@johnku2011/bwai`** (`npx @johnku2011/bwai`; CLI command `bwai`). Landing page: [`site/`](../site/) → GitHub Pages.
 
 ## Commands (this repo)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ runnable project plus a curated `SKILL.md` skill set wired for Claude, Cursor,
 Codex, and Copilot, with NVIDIA SkillSpector gating and a `skills.lock`
 provenance file.
 
-Contributing: see [`CONTRIBUTING.md`](./CONTRIBUTING.md). Published on npm as **`@johnku2011/bwai`** (`npx @johnku2011/bwai`; CLI command `bwai`). Landing page: [`site/`](../site/) → GitHub Pages.
+Contributing: see [`CONTRIBUTING.md`](./CONTRIBUTING.md). Published on npm as **`bwai-cli`** (`npx bwai-cli`). Landing page: [`site/`](../site/) → GitHub Pages.
 
 ## Commands (this repo)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,12 +109,12 @@ See [`docs/superpowers-upstream.md`](./docs/superpowers-upstream.md).
 - [ ] README / ROADMAP updated for user-visible changes
 - [ ] No unrelated refactors
 
-## Publishing `bwai` to npm
+## Publishing `@johnku2011/bwai` to npm
 
 Maintainers only — requires a **Granular access token** (Classic tokens were removed in 2025) with **Read and write** permission and **Bypass 2FA** enabled at creation. See [`docs/npm-publish.md`](./docs/npm-publish.md).
 
 1. https://www.npmjs.com/settings/~your-user~/tokens → **Granular Access Token**  
-2. Permissions: Read and write · **Bypass 2FA: On** · Packages: all (or sufficient scope for `bwai`)  
+2. Permissions: Read and write · **Bypass 2FA: On** · Packages: all (or scope `@johnku2011`)  
 3. Add repo secret `NPM_TOKEN` (token starts with `npm_`)  
 4. Run **Actions → Publish to npm**, or locally:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,12 +109,12 @@ See [`docs/superpowers-upstream.md`](./docs/superpowers-upstream.md).
 - [ ] README / ROADMAP updated for user-visible changes
 - [ ] No unrelated refactors
 
-## Publishing `@johnku2011/bwai` to npm
+## Publishing `bwai-cli` to npm
 
 Maintainers only — requires a **Granular access token** (Classic tokens were removed in 2025) with **Read and write** permission and **Bypass 2FA** enabled at creation. See [`docs/npm-publish.md`](./docs/npm-publish.md).
 
 1. https://www.npmjs.com/settings/~your-user~/tokens → **Granular Access Token**  
-2. Permissions: Read and write · **Bypass 2FA: On** · Packages: all (or scope `@johnku2011`)  
+2. Permissions: Read and write · **Bypass 2FA: On** · Packages: all  
 3. Add repo secret `NPM_TOKEN` (token starts with `npm_`)  
 4. Run **Actions → Publish to npm**, or locally:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [`requirements.md`](./requirements.md) for the full spec and
 for why this project focuses on *bundling starters with vetted skills* and a
 *security gate* rather than reinventing skill formats, installers, or directories.
 
-> Status: Phase 2D — npm package **`@johnku2011/bwai`** (CLI command: `bwai`), `CONTRIBUTING.md`, `fastify-api` and
+> Status: Phase 2D — npm package **`bwai-cli`**, `CONTRIBUTING.md`, `fastify-api` and
 > `python-service` boilerplates. See [`ROADMAP.md`](./ROADMAP.md).
 >
 > Boilerplates: `nextjs-app`, `express-api`, `fastify-api`, `python-service`,
@@ -21,8 +21,8 @@ for why this project focuses on *bundling starters with vetted skills* and a
 **From npm** (recommended):
 
 ```bash
-npx @johnku2011/bwai list-boilerplates
-npx @johnku2011/bwai new node-service ./my-app --agents claude,cursor
+npx bwai-cli list-boilerplates
+npx bwai-cli new node-service ./my-app --agents claude,cursor
 ```
 
 **Landing page:** deploy [`site/`](../site/) to **Vercel** (root dir `site`, no build) or GitHub Pages — see [`docs/landing-deploy.md`](./landing-deploy.md).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [`requirements.md`](./requirements.md) for the full spec and
 for why this project focuses on *bundling starters with vetted skills* and a
 *security gate* rather than reinventing skill formats, installers, or directories.
 
-> Status: Phase 2D — npm package **`bwai`**, `CONTRIBUTING.md`, `fastify-api` and
+> Status: Phase 2D — npm package **`@johnku2011/bwai`** (CLI command: `bwai`), `CONTRIBUTING.md`, `fastify-api` and
 > `python-service` boilerplates. See [`ROADMAP.md`](./ROADMAP.md).
 >
 > Boilerplates: `nextjs-app`, `express-api`, `fastify-api`, `python-service`,
@@ -18,13 +18,11 @@ for why this project focuses on *bundling starters with vetted skills* and a
 
 ## Install
 
-## Install
-
 **From npm** (recommended):
 
 ```bash
-npx bwai list-boilerplates
-npx bwai new node-service ./my-app --agents claude,cursor
+npx @johnku2011/bwai list-boilerplates
+npx @johnku2011/bwai new node-service ./my-app --agents claude,cursor
 ```
 
 **Landing page:** deploy [`site/`](../site/) to **Vercel** (root dir `site`, no build) or GitHub Pages — see [`docs/landing-deploy.md`](./landing-deploy.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Deepened skills, `deploy-vercel`, `sync-upstream`, Superpowers alignment doc.
 
 | Item | Status |
 | --- | --- |
-| npm package **`@johnku2011/bwai`** (v0.2.0, `prepublishOnly`, publish workflow) | Done |
+| npm package **`bwai-cli`** (v0.2.1, `prepublishOnly`, publish workflow) | Done |
 | `fastify-api` boilerplate | Done |
 | `python-service` boilerplate (FastAPI + pytest) | Done |
 | `CONTRIBUTING.md` | Done |
@@ -38,8 +38,8 @@ Deepened skills, `deploy-vercel`, `sync-upstream`, Superpowers alignment doc.
 ## Commands reference
 
 ```bash
-npx @johnku2011/bwai list-boilerplates
-npx @johnku2011/bwai new <boilerplate> [dir] --agents claude,cursor
+npx bwai-cli list-boilerplates
+npx bwai-cli new <boilerplate> [dir] --agents claude,cursor
 bwai scan-catalog --threshold 30 --require-scanner
 bwai scan-project [dir] --threshold 50 --require-scanner
 bwai search-skills [query] --source all --scan 5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Deepened skills, `deploy-vercel`, `sync-upstream`, Superpowers alignment doc.
 
 | Item | Status |
 | --- | --- |
-| npm package **`bwai`** (v0.2.0, `prepublishOnly`, publish workflow) | Done |
+| npm package **`@johnku2011/bwai`** (v0.2.0, `prepublishOnly`, publish workflow) | Done |
 | `fastify-api` boilerplate | Done |
 | `python-service` boilerplate (FastAPI + pytest) | Done |
 | `CONTRIBUTING.md` | Done |
@@ -38,8 +38,8 @@ Deepened skills, `deploy-vercel`, `sync-upstream`, Superpowers alignment doc.
 ## Commands reference
 
 ```bash
-npx bwai list-boilerplates
-npx bwai new <boilerplate> [dir] --agents claude,cursor
+npx @johnku2011/bwai list-boilerplates
+npx @johnku2011/bwai new <boilerplate> [dir] --agents claude,cursor
 bwai scan-catalog --threshold 30 --require-scanner
 bwai scan-project [dir] --threshold 50 --require-scanner
 bwai search-skills [query] --source all --scan 5

--- a/docs/npm-publish.md
+++ b/docs/npm-publish.md
@@ -1,9 +1,8 @@
-# Publishing `@johnku2011/bwai` to npm
+# Publishing `bwai-cli` to npm
 
-> **Package name:** npm blocks the unscoped name `bwai` (too similar to existing packages). Publish as **`@johnku2011/bwai`**. The CLI command remains **`bwai`** after install.
-
-> **Note (2025+):** npm removed **Classic** tokens. Use **Granular access tokens** only.
-> See [npm: About access tokens](https://docs.npmjs.com/about-access-tokens/).
+> **Package name:** npm blocks the short name `bwai` (too similar to existing packages). Publish as **`bwai-cli`**. The CLI commands are **`bwai-cli`** (primary) and **`bwai`** (alias).
+>
+> An earlier scoped publish (`@johnku2011/bwai@0.2.0`) remains on npm but is deprecated in favor of `bwai-cli`.
 
 ## Quick publish (maintainer, interactive)
 
@@ -25,7 +24,7 @@ Automated publish needs a **Granular access token** with **Bypass 2FA** enabled 
 2. **Generate New Token** → **Granular Access Token**  
 3. Configure:
    - **Permissions:** Read and write  
-   - **Packages and scopes:** All packages (or scope `@johnku2011` so `@johnku2011/bwai` can be created)  
+   - **Packages and scopes:** All packages  
    - **Expiration:** up to 90 days for write tokens  
    - **Bypass two-factor authentication (2FA):** **On** ← required for non-interactive publish  
 4. Copy the token (starts with `npm_`)  
@@ -42,13 +41,13 @@ Verify:
 
 ```bash
 npm whoami
-npm pack && npm install -g ./johnku2011-bwai-0.2.0.tgz && bwai list-boilerplates
+npm pack && npm install -g ./bwai-cli-0.2.1.tgz && bwai-cli list-boilerplates
 npm publish --access public
 ```
 
 ### Do you need an npm organization?
 
-**No.** Publish `@johnku2011/bwai` under your user account (`johnku2011`). You do not need an npm organization for a scoped user package.
+**No.** Publish `bwai-cli` under your user account (`johnku2011`).
 
 ## Common errors
 
@@ -58,7 +57,7 @@ npm publish --access public
 403 Forbidden - Package name too similar to existing packages ... try '@johnku2011/bwai'
 ```
 
-**Fix:** Use scoped name `@johnku2011/bwai` in `package.json` (already set in this repo).
+**Fix:** Use **`bwai-cli`** (unscoped) instead of `bwai`. Do not use `@johnku2011/bwai` for new installs.
 
 ### Two-factor / token (403)
 
@@ -84,8 +83,8 @@ Requires repo secret `NPM_TOKEN` = granular token with bypass 2FA.
 ## After publish
 
 ```bash
-npm view @johnku2011/bwai
-npx @johnku2011/bwai list-boilerplates
+npm view bwai-cli
+npx bwai-cli list-boilerplates
 ```
 
-Package page: https://www.npmjs.com/package/@johnku2011/bwai
+Package page: https://www.npmjs.com/package/bwai-cli

--- a/docs/npm-publish.md
+++ b/docs/npm-publish.md
@@ -1,4 +1,6 @@
-# Publishing `bwai` to npm
+# Publishing `@johnku2011/bwai` to npm
+
+> **Package name:** npm blocks the unscoped name `bwai` (too similar to existing packages). Publish as **`@johnku2011/bwai`**. The CLI command remains **`bwai`** after install.
 
 > **Note (2025+):** npm removed **Classic** tokens. Use **Granular access tokens** only.
 > See [npm: About access tokens](https://docs.npmjs.com/about-access-tokens/).
@@ -23,7 +25,7 @@ Automated publish needs a **Granular access token** with **Bypass 2FA** enabled 
 2. **Generate New Token** → **Granular Access Token**  
 3. Configure:
    - **Permissions:** Read and write  
-   - **Packages and scopes:** All packages (or add scope access so the new `bwai` package can be created)  
+   - **Packages and scopes:** All packages (or scope `@johnku2011` so `@johnku2011/bwai` can be created)  
    - **Expiration:** up to 90 days for write tokens  
    - **Bypass two-factor authentication (2FA):** **On** ← required for non-interactive publish  
 4. Copy the token (starts with `npm_`)  
@@ -40,15 +42,25 @@ Verify:
 
 ```bash
 npm whoami
-npm pack && npm install -g ./bwai-0.2.0.tgz && bwai list-boilerplates
+npm pack && npm install -g ./johnku2011-bwai-0.2.0.tgz && bwai list-boilerplates
 npm publish --access public
 ```
 
 ### Do you need an npm organization?
 
-**No.** Publish `bwai` under your user account (`johnku2011`). Organizations are optional (mainly for `@scope/package` names or teams).
+**No.** Publish `@johnku2011/bwai` under your user account (`johnku2011`). You do not need an npm organization for a scoped user package.
 
-## Common error
+## Common errors
+
+### Package name too similar (403)
+
+```
+403 Forbidden - Package name too similar to existing packages ... try '@johnku2011/bwai'
+```
+
+**Fix:** Use scoped name `@johnku2011/bwai` in `package.json` (already set in this repo).
+
+### Two-factor / token (403)
 
 ```
 403 Forbidden - Two-factor authentication or granular access token with bypass 2fa enabled is required
@@ -72,8 +84,8 @@ Requires repo secret `NPM_TOKEN` = granular token with bypass 2FA.
 ## After publish
 
 ```bash
-npm view bwai
-npx bwai list-boilerplates
+npm view @johnku2011/bwai
+npx @johnku2011/bwai list-boilerplates
 ```
 
-Package page: https://www.npmjs.com/package/bwai
+Package page: https://www.npmjs.com/package/@johnku2011/bwai

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "@johnku2011/bwai",
-  "version": "0.2.0",
+  "name": "bwai-cli",
+  "version": "0.2.1",
   "description": "Security-vetted, cross-agent project boilerplates. Scaffold a project pre-wired with curated, SkillSpector-gated agent skills.",
   "type": "module",
   "bin": {
+    "bwai-cli": "dist/cli.js",
     "bwai": "dist/cli.js"
   },
   "files": [
@@ -40,7 +41,8 @@
     "copilot",
     "skillspector",
     "security",
-    "bwai"
+    "bwai",
+    "bwai-cli"
   ],
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bwai",
+  "name": "@johnku2011/bwai",
   "version": "0.2.0",
   "description": "Security-vetted, cross-agent project boilerplates. Scaffold a project pre-wired with curated, SkillSpector-gated agent skills.",
   "type": "module",

--- a/site/index.html
+++ b/site/index.html
@@ -33,7 +33,7 @@
             <code>skills.lock</code> provenance file.
           </p>
           <div class="install">
-            <pre><code>npx @johnku2011/bwai new node-service ./my-app --agents claude,cursor
+            <pre><code>npx bwai-cli new node-service ./my-app --agents claude,cursor
 bwai scan-project ./my-app --threshold 50</code></pre>
             <p class="install-note">Requires Node.js 20+. Install globally: <code>npm i -g bwai</code></p>
           </div>
@@ -96,8 +96,8 @@ bwai scan-project ./my-app --threshold 50</code></pre>
       <section class="section">
         <div class="container cta">
           <h2>Get started</h2>
-          <pre><code>npx @johnku2011/bwai list-boilerplates
-npx @johnku2011/bwai new fastify-api ./api --agents claude,cursor,copilot</code></pre>
+          <pre><code>npx bwai-cli list-boilerplates
+npx bwai-cli new fastify-api ./api --agents claude,cursor,copilot</code></pre>
           <p>
             <a class="button" href="https://www.npmjs.com/package/bwai">npm</a>
             <a class="button button-secondary" href="https://github.com/johnku2011/boilerplates-with-ai-skills/blob/main/CONTRIBUTING.md">Contribute</a>

--- a/site/index.html
+++ b/site/index.html
@@ -33,7 +33,7 @@
             <code>skills.lock</code> provenance file.
           </p>
           <div class="install">
-            <pre><code>npx bwai new node-service ./my-app --agents claude,cursor
+            <pre><code>npx @johnku2011/bwai new node-service ./my-app --agents claude,cursor
 bwai scan-project ./my-app --threshold 50</code></pre>
             <p class="install-note">Requires Node.js 20+. Install globally: <code>npm i -g bwai</code></p>
           </div>
@@ -96,8 +96,8 @@ bwai scan-project ./my-app --threshold 50</code></pre>
       <section class="section">
         <div class="container cta">
           <h2>Get started</h2>
-          <pre><code>npx bwai list-boilerplates
-npx bwai new fastify-api ./api --agents claude,cursor,copilot</code></pre>
+          <pre><code>npx @johnku2011/bwai list-boilerplates
+npx @johnku2011/bwai new fastify-api ./api --agents claude,cursor,copilot</code></pre>
           <p>
             <a class="button" href="https://www.npmjs.com/package/bwai">npm</a>
             <a class="button button-secondary" href="https://github.com/johnku2011/boilerplates-with-ai-skills/blob/main/CONTRIBUTING.md">Contribute</a>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,12 +22,12 @@ import {
 const program = new Command();
 
 program
-  .name("bwai")
+  .name("bwai-cli")
   .description(
     "boilerplates-with-ai-skills: scaffold projects pre-wired with curated, " +
       "security-vetted, cross-agent AI skills.",
   )
-  .version("0.1.0");
+  .version("0.2.1");
 
 program
   .command("list-boilerplates")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clarifies npm publish status and switches to an easier package name.

**Previous state:** Publish did **not** fail — `@johnku2011/bwai@0.2.0` went live, but npm rejected the short name `bwai` and the scoped install path is awkward.

**New primary package:** **`bwai-cli@0.2.1`** (unscoped, simple `npx bwai-cli`)

## Name review

| Name | npm status | Install UX |
|------|------------|------------|
| `bwai` | Blocked (too similar to `ai`, `b4a`, etc.) | — |
| `@johnku2011/bwai` | Published 0.2.0, now **deprecated** | `npx @johnku2011/bwai` |
| **`bwai-cli`** | **Published 0.2.1** | **`npx bwai-cli`** |

## Changes

- Rename package to `bwai-cli`, bump to `0.2.1`
- Bin aliases: `bwai-cli` (primary) and `bwai`
- Update README, landing page, ROADMAP, publish docs
- Deprecate `@johnku2011/bwai` on npm with message pointing to `bwai-cli`

## Verify

```bash
npm view bwai-cli version   # 0.2.1
npx bwai-cli list-boilerplates
```

https://www.npmjs.com/package/bwai-cli

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8de4f6a-a148-48fe-943d-747c48349690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

