### PR TITLE
Deepen catalog discovery into a validated snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 # Local runtime state written by the CLI in scaffolded projects
 .bwai/
 .getsuperpower/
+.worktrees/
 
 # Editor / OS
 .DS_Store

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# bwai Catalog
+
+The bwai catalog is the curated set of project starters and agent resources that the CLI can validate, scan, package, and scaffold.
+
+## Language
+
+**Catalog Artifact**:
+A boilerplate, skill, or workflow stored in the catalog.
+_Avoid_: Catalog item, resource
+
+**Catalog Snapshot**:
+A complete in-memory description of discovered Catalog Artifacts and every diagnostic found while loading them. An invalid artifact remains represented rather than disappearing silently.
+_Avoid_: Catalog scan, catalog index
+
+**Catalog Diagnostic**:
+A structured finding that identifies an invalid or suspicious relationship among Catalog Artifacts.
+_Avoid_: Validation message, loader error
+
+**Catalog Artifact Identity**:
+The stable, scope-qualified identity of a Catalog Artifact. Boilerplates use `boilerplate:<name>`; Shared Skills use `shared:<skill-name>`; Local Skills use `boilerplate:<boilerplate-name>/skills/<skill-name>`; shared workflows use `shared:workflows/<name>`; local workflows use `boilerplate:<boilerplate-name>/workflow/<name>`.
+_Avoid_: Label, path, short name
+
+**Local Skill**:
+A skill owned by one boilerplate and declared by that boilerplate's manifest. A local skill directory without its declaration is catalog drift.
+_Avoid_: Boilerplate-specific skill, private skill
+
+**Shared Skill**:
+A catalog skill available for multiple boilerplates to declare. It remains valid when no boilerplate currently bundles it.
+_Avoid_: Global skill, common skill

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,6 +53,30 @@ app/
 
 Omit `workflow` for boilerplates that only need skills (e.g. `react-native-app` today).
 
+## Catalog snapshot
+
+Every catalog reader loads one immutable snapshot of boilerplates, skills, and workflows. The
+snapshot assigns scope-qualified identities, validates metadata and relationships, and accumulates
+diagnostics before strict commands perform work. This keeps discovery, reference resolution, and
+identity rules inside one module instead of reconstructing them in each command.
+
+Artifact identities encode scope explicitly:
+
+- Shared skill: `shared:code-review`
+- Boilerplate-local skill: `boilerplate:nextjs-app/skills/nextjs-app-router`
+- Shared workflow: `shared:workflows/bwai-delivery`
+- Boilerplate-local workflow: `boilerplate:<boilerplate>/workflow/<workflow>`
+
+Validation covers manifests and metadata, required templates, declared skill and workflow
+references, undeclared local skills, duplicate declarations and identities, and install-name
+collisions. `list-boilerplates` prints valid entries plus diagnostics and exits non-zero for an
+invalid catalog. SkillSpector and runnable-template checks remain separate gates.
+
+`registry/skills-index.json` uses index version 2 and stores the canonical skill identity in each
+entry. Version 1 registries remain readable: `loadRegistry` migrates them in memory, deriving shared
+IDs from the skill name and local IDs from their scope-qualified catalog path. Registry writes always
+emit version 2.
+
 ## CLI source layout
 
 ```

--- a/docs/superpowers/plans/2026-08-24-catalog-snapshot.md
+++ b/docs/superpowers/plans/2026-08-24-catalog-snapshot.md
@@ -1,0 +1,916 @@
+# Validated Catalog Snapshot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace fragmented catalog discovery with one immutable Catalog Snapshot that assigns canonical identities, accumulates structured diagnostics, and supplies every catalog consumer.
+
+**Architecture:** Add a deep `catalog-snapshot` module that discovers, parses, indexes, and relates catalog artifacts in four deterministic phases. Keep compatibility exports in `catalog.ts`, then migrate scan, registry, scaffold, export, doctor, promotion, and synchronization to consume snapshot data instead of reconstructing identity or relationships.
+
+**Tech Stack:** TypeScript 6, Node.js 20+ ESM, Zod 4, Commander 15, Vitest 4, `node:fs/promises`.
+
+## Global Constraints
+
+- Canonical identities are `boilerplate:<name>`, `shared:<skill-name>`, `boilerplate:<boilerplate-name>/skills/<skill-name>`, `shared:workflows/<name>`, and `boilerplate:<boilerplate-name>/workflow/<name>`.
+- Snapshot validation covers metadata and relationships only; do not run SkillSpector or execute templates while loading.
+- Accumulate all expected catalog problems as diagnostics; do not fail at the first invalid artifact.
+- Invalid discovered artifacts remain in `artifacts`; only valid artifacts enter typed collections.
+- An undeclared Local Skill is an error; an unbundled Shared Skill is valid.
+- Skill short names must be unique within each boilerplate install set, regardless of scope.
+- Snapshots are immutable and never cached process-wide.
+- Registry version 1 loads; every registry save writes version 2.
+- Keep transactional mutation/rollback, safety-gate consolidation, plugin reconciliation, template execution, watch mode, and filesystem abstraction out of scope.
+
+## File Map
+
+- Create `src/catalog-snapshot.ts` — snapshot types, discovery phases, identity, diagnostics, validity gate.
+- Create `tests/catalog-fixture.ts` — small complete temporary-catalog builder used by snapshot and consumer tests.
+- Create `tests/catalog-snapshot.test.ts` — snapshot interface and diagnostic contract tests.
+- Create `tests/cli-list.test.ts` — partial list output and non-zero result behavior.
+- Create `src/list-boilerplates-command.ts` — testable CLI presentation and exit-result adapter.
+- Modify `src/schema.ts` — workflow metadata schema.
+- Modify `src/catalog.ts` — compatibility facade over the snapshot.
+- Modify `src/cli.ts` — injectable list action that renders diagnostics and returns an exit result.
+- Modify `src/catalog-scan.ts` — enumerate canonical snapshot skills.
+- Modify `src/registry.ts` — registry v1 migration, v2 schema, identity-based construction and scan updates.
+- Modify `src/scaffold.ts`, `src/export-plugin.ts`, `src/doctor.ts`, `src/promote.ts`, `src/sync-skills.ts`, and `src/upstream-sync.ts` — use snapshot-derived catalog state.
+- Modify `src/index.ts` — export snapshot interface.
+- Modify affected tests plus `docs/ARCHITECTURE.md` and `registry/skills-index.json`.
+
+---
+
+### Task 1: Build the snapshot foundation and workflow schema
+
+**Files:**
+- Create: `tests/catalog-fixture.ts`
+- Create: `tests/catalog-snapshot.test.ts`
+- Create: `src/catalog-snapshot.ts`
+- Modify: `src/schema.ts`
+
+**Interfaces:**
+- Consumes: `boilerplateManifestSchema`, `assertSkillCompliant`, and default roots from `src/paths.ts`.
+- Produces: `CatalogRoots`, `CatalogArtifactIdentity`, `CatalogDiagnostic`, `CatalogArtifactRecord`, `CatalogSkill`, `CatalogWorkflow`, `CatalogSnapshot`, `CatalogValidationError`, `loadCatalogSnapshot(options?)`, and `assertValidCatalog(snapshot)`.
+
+- [ ] **Step 1: Add a reusable complete catalog fixture**
+
+Create `tests/catalog-fixture.ts` with helpers that always create all three roots so missing-root behavior is intentional in individual tests:
+
+```ts
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface CatalogFixture {
+  root: string;
+  boilerplatesDir: string;
+  sharedSkillsDir: string;
+  sharedWorkflowsDir: string;
+}
+
+export async function createCatalogFixture(root: string): Promise<CatalogFixture> {
+  const fixture = {
+    root,
+    boilerplatesDir: join(root, "boilerplates"),
+    sharedSkillsDir: join(root, "shared", "skills"),
+    sharedWorkflowsDir: join(root, "shared", "workflows"),
+  };
+  await Promise.all([
+    mkdir(fixture.boilerplatesDir, { recursive: true }),
+    mkdir(fixture.sharedSkillsDir, { recursive: true }),
+    mkdir(fixture.sharedWorkflowsDir, { recursive: true }),
+  ]);
+  return fixture;
+}
+
+export async function writeSkill(dir: string, name: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: Use when testing ${name} catalog behavior.\nlicense: MIT\n---\n\n# ${name}\n`,
+    "utf8",
+  );
+}
+
+export async function writeBoilerplate(
+  fixture: CatalogFixture,
+  directoryName: string,
+  manifest: Record<string, unknown>,
+): Promise<string> {
+  const dir = join(fixture.boilerplatesDir, directoryName);
+  await mkdir(join(dir, "template"), { recursive: true });
+  await mkdir(join(dir, "skills"), { recursive: true });
+  await writeFile(join(dir, "boilerplate.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  return dir;
+}
+
+export function boilerplateManifest(
+  name: string,
+  skills: Array<{ name: string; source: "local" | "shared" }> = [],
+  workflow?: { name: string; source: "local" | "shared" },
+): Record<string, unknown> {
+  return {
+    name,
+    description: `${name} test boilerplate`,
+    stack: "test",
+    version: "1.0.0",
+    defaultAgents: ["claude"],
+    skills,
+    ...(workflow ? { workflow } : {}),
+  };
+}
+```
+
+- [ ] **Step 2: Write failing happy-path and invalid-record tests**
+
+In `tests/catalog-snapshot.test.ts`, create one valid shared skill and boilerplate, then assert canonical identity and immutability. Add malformed-manifest and missing-root cases:
+
+```ts
+const snapshot = await loadCatalogSnapshot(fixture);
+expect(snapshot.valid).toBe(true);
+expect(snapshot.skills.map((skill) => skill.id)).toContain("shared:code-review");
+expect(snapshot.boilerplates.map((bp) => bp.id)).toContain("boilerplate:demo");
+expect(Object.isFrozen(snapshot)).toBe(true);
+
+const malformed = await loadCatalogSnapshot(fixture);
+expect(malformed.valid).toBe(false);
+expect(malformed.artifacts).toEqual(
+  expect.arrayContaining([expect.objectContaining({ kind: "boilerplate", valid: false })]),
+);
+expect(malformed.diagnostics.map((d) => d.code)).toContain("INVALID_BOILERPLATE_MANIFEST");
+```
+
+- [ ] **Step 3: Run the focused tests and verify red**
+
+Run: `npm test -- tests/catalog-snapshot.test.ts`
+
+Expected: FAIL because `src/catalog-snapshot.ts` and the workflow schema do not exist.
+
+- [ ] **Step 4: Add the workflow schema**
+
+In `src/schema.ts`, export schemas that match the approved metadata contract:
+
+```ts
+const catalogNameSchema = z
+  .string()
+  .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, "name must be lowercase-hyphen-case");
+
+export const workflowManifestSchema = z
+  .object({
+    schemaVersion: z.string().min(1),
+    name: catalogNameSchema,
+    version: z.string().min(1),
+    description: z.string().min(1),
+    skills: z.array(z.object({ source: z.string().min(1), repo: z.string().min(1).optional() })),
+    steps: z.array(
+      z.object({
+        id: z.string().min(1),
+        title: z.string().min(1),
+        skill: z.string().min(1),
+        gate: z.string().min(1).optional(),
+      }),
+    ),
+  })
+  .superRefine((workflow, ctx) => {
+    const seen = new Set<string>();
+    for (const [index, step] of workflow.steps.entries()) {
+      if (seen.has(step.id)) {
+        ctx.addIssue({ code: "custom", path: ["steps", index, "id"], message: "step id must be unique" });
+      }
+      seen.add(step.id);
+    }
+  });
+
+export type WorkflowManifest = z.infer<typeof workflowManifestSchema>;
+```
+
+Reuse `catalogNameSchema` inside `boilerplateManifestSchema` so both metadata formats enforce the same names.
+
+- [ ] **Step 5: Implement discovery, parsing, identity, and the validity gate**
+
+Create `src/catalog-snapshot.ts` with the exact public shape:
+
+```ts
+export interface CatalogRoots {
+  boilerplatesDir: string;
+  sharedSkillsDir: string;
+  sharedWorkflowsDir: string;
+}
+
+export type CatalogArtifactIdentity =
+  | `boilerplate:${string}`
+  | `shared:${string}`
+  | `boilerplate:${string}/skills/${string}`
+  | `shared:workflows/${string}`
+  | `boilerplate:${string}/workflow/${string}`;
+
+export type CatalogDiagnosticCode =
+  | "CATALOG_ROOT_UNREADABLE"
+  | "INVALID_BOILERPLATE_MANIFEST"
+  | "BOILERPLATE_NAME_MISMATCH"
+  | "DUPLICATE_ARTIFACT_IDENTITY"
+  | "MISSING_TEMPLATE"
+  | "INVALID_SKILL_METADATA"
+  | "MISSING_DECLARED_SKILL"
+  | "UNDECLARED_LOCAL_SKILL"
+  | "DUPLICATE_SKILL_DECLARATION"
+  | "SKILL_INSTALL_NAME_COLLISION"
+  | "INVALID_WORKFLOW_METADATA"
+  | "MISSING_DECLARED_WORKFLOW";
+
+export interface CatalogDiagnostic {
+  code: CatalogDiagnosticCode;
+  severity: "error" | "warning";
+  kind: "catalog" | "boilerplate" | "skill" | "workflow";
+  path: string;
+  identity?: CatalogArtifactIdentity;
+  message: string;
+}
+
+export interface CatalogArtifactRecord {
+  kind: "boilerplate" | "skill" | "workflow";
+  path: string;
+  identity?: CatalogArtifactIdentity;
+  valid: boolean;
+}
+
+export interface CatalogSkill {
+  id: CatalogArtifactIdentity;
+  name: string;
+  scope: "shared" | "local";
+  dir: string;
+  boilerplateName?: string;
+}
+
+export interface CatalogWorkflow {
+  id: CatalogArtifactIdentity;
+  name: string;
+  scope: "shared" | "local";
+  dir: string;
+  manifest: WorkflowManifest;
+  boilerplateName?: string;
+}
+
+export interface CatalogBoilerplate {
+  id: CatalogArtifactIdentity;
+  manifest: BoilerplateManifest;
+  dir: string;
+  templateDir: string;
+  skillsDir: string;
+  skills: CatalogSkill[];
+  workflow?: CatalogWorkflow;
+}
+
+export interface CatalogSnapshot {
+  roots: Readonly<CatalogRoots>;
+  artifacts: readonly CatalogArtifactRecord[];
+  boilerplates: readonly CatalogBoilerplate[];
+  skills: readonly CatalogSkill[];
+  workflows: readonly CatalogWorkflow[];
+  diagnostics: readonly CatalogDiagnostic[];
+  valid: boolean;
+}
+
+export class CatalogValidationError extends Error {
+  constructor(readonly diagnostics: readonly CatalogDiagnostic[]) {
+    super(`Catalog validation failed with ${diagnostics.length} error(s)`);
+    this.name = "CatalogValidationError";
+  }
+}
+
+export function assertValidCatalog(snapshot: CatalogSnapshot): void {
+  const errors = snapshot.diagnostics.filter((diagnostic) => diagnostic.severity === "error");
+  if (errors.length > 0) throw new CatalogValidationError(errors);
+}
+```
+
+Implement `loadCatalogSnapshot(options: Partial<CatalogRoots> = {})` using directory entries from `readdir(root, { withFileTypes: true })`, sorted by `entry.name`, plus `node:path` helpers, `boilerplateManifestSchema`, `workflowManifestSchema`, and `assertSkillCompliant(content, { directoryName, requireEnrichment: true })`. Convert JSON/Zod/frontmatter failures into artifact records plus diagnostics. Freeze returned arrays, roots, artifact objects, and the snapshot object.
+
+- [ ] **Step 6: Run the focused tests and verify green**
+
+Run: `npm test -- tests/catalog-snapshot.test.ts tests/workflows.test.ts tests/skill-frontmatter.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the foundation**
+
+```bash
+git add src/schema.ts src/catalog-snapshot.ts tests/catalog-fixture.ts tests/catalog-snapshot.test.ts
+git commit -m "feat: add validated catalog snapshot foundation"
+```
+
+---
+
+### Task 2: Add relationship validation and complete diagnostics
+
+**Files:**
+- Modify: `src/catalog-snapshot.ts`
+- Modify: `tests/catalog-snapshot.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 snapshot types and loader.
+- Produces: fully related `CatalogBoilerplate.skills`, `CatalogBoilerplate.workflow`, and the complete diagnostic-code behavior promised by Task 1.
+
+- [ ] **Step 1: Write failing relationship tests**
+
+Add table-driven fixture cases with explicit setup functions:
+
+```ts
+const cases: Array<{
+  title: string;
+  code: CatalogDiagnosticCode;
+  arrange: (fixture: CatalogFixture) => Promise<void>;
+}> = [
+  {
+    title: "missing declared shared skill",
+    code: "MISSING_DECLARED_SKILL",
+    arrange: async (fixture) => {
+      await writeBoilerplate(
+        fixture,
+        "demo",
+        boilerplateManifest("demo", [{ name: "absent", source: "shared" }]),
+      );
+    },
+  },
+  {
+    title: "undeclared local skill",
+    code: "UNDECLARED_LOCAL_SKILL",
+    arrange: async (fixture) => {
+      const dir = await writeBoilerplate(fixture, "demo", boilerplateManifest("demo"));
+      await writeSkill(join(dir, "skills", "logger"), "logger");
+    },
+  },
+  {
+    title: "duplicate declaration",
+    code: "DUPLICATE_SKILL_DECLARATION",
+    arrange: async (fixture) => {
+      await writeSkill(join(fixture.sharedSkillsDir, "logger"), "logger");
+      await writeBoilerplate(
+        fixture,
+        "demo",
+        boilerplateManifest("demo", [
+          { name: "logger", source: "shared" },
+          { name: "logger", source: "shared" },
+        ]),
+      );
+    },
+  },
+  {
+    title: "shared/local install-name collision",
+    code: "SKILL_INSTALL_NAME_COLLISION",
+    arrange: async (fixture) => {
+      await writeSkill(join(fixture.sharedSkillsDir, "logger"), "logger");
+      const dir = await writeBoilerplate(
+        fixture,
+        "demo",
+        boilerplateManifest("demo", [
+          { name: "logger", source: "shared" },
+          { name: "logger", source: "local" },
+        ]),
+      );
+      await writeSkill(join(dir, "skills", "logger"), "logger");
+    },
+  },
+  {
+    title: "missing declared workflow",
+    code: "MISSING_DECLARED_WORKFLOW",
+    arrange: async (fixture) => {
+      await writeBoilerplate(
+        fixture,
+        "demo",
+        boilerplateManifest("demo", [], { name: "delivery", source: "shared" }),
+      );
+    },
+  },
+  {
+    title: "directory and manifest mismatch",
+    code: "BOILERPLATE_NAME_MISMATCH",
+    arrange: async (fixture) => {
+      await writeBoilerplate(fixture, "folder-name", boilerplateManifest("manifest-name"));
+    },
+  },
+];
+
+it.each(cases)("reports $title", async ({ arrange, code }) => {
+  const root = await mkdtemp(join(tmpdir(), "bwai-catalog-relation-"));
+  try {
+    const fixture = await createCatalogFixture(root);
+    await arrange(fixture);
+    const snapshot = await loadCatalogSnapshot(fixture);
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain(code);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+```
+
+Add a positive test proving `boilerplate:a/skills/logger` and `boilerplate:b/skills/logger` coexist, and a deterministic-order test comparing diagnostics to a copy sorted by `[path, code]`.
+
+- [ ] **Step 2: Run the focused tests and verify red**
+
+Run: `npm test -- tests/catalog-snapshot.test.ts`
+
+Expected: FAIL on each relationship diagnostic not yet produced.
+
+- [ ] **Step 3: Implement indexing and relation phases**
+
+Inside `loadCatalogSnapshot`, build `Map<CatalogArtifactIdentity, CatalogSkill | CatalogWorkflow | CatalogBoilerplate>` indexes. For each valid boilerplate:
+
+```ts
+const seenDeclarations = new Set<string>();
+const seenInstallNames = new Map<string, CatalogArtifactIdentity>();
+
+for (const ref of manifest.skills) {
+  const id = ref.source === "shared"
+    ? (`shared:${ref.name}` as const)
+    : (`boilerplate:${manifest.name}/skills/${ref.name}` as const);
+  const declarationKey = `${ref.source}:${ref.name}`;
+  if (seenDeclarations.has(declarationKey)) {
+    diagnostics.push({
+      code: "DUPLICATE_SKILL_DECLARATION",
+      severity: "error",
+      kind: "boilerplate",
+      path: boilerplate.dir,
+      identity: boilerplate.id,
+      message: `Duplicate skill declaration: ${declarationKey}`,
+    });
+  }
+  seenDeclarations.add(declarationKey);
+  const previous = seenInstallNames.get(ref.name);
+  if (previous && previous !== id) {
+    diagnostics.push({
+      code: "SKILL_INSTALL_NAME_COLLISION",
+      severity: "error",
+      kind: "boilerplate",
+      path: boilerplate.dir,
+      identity: boilerplate.id,
+      message: `Skill install name ${ref.name} resolves to both ${previous} and ${id}`,
+    });
+  }
+  seenInstallNames.set(ref.name, id);
+  const skill = skillsById.get(id);
+  if (!skill) {
+    diagnostics.push({
+      code: "MISSING_DECLARED_SKILL",
+      severity: "error",
+      kind: "boilerplate",
+      path: boilerplate.dir,
+      identity: boilerplate.id,
+      message: `Declared skill not found: ${id}`,
+    });
+  }
+  else resolvedSkills.push(skill);
+}
+```
+
+Compare every Local Skill discovered under a boilerplate to its declared local identities and emit `UNDECLARED_LOCAL_SKILL` for leftovers. Resolve workflow references the same way and verify workflow manifest name against declaration and shared directory name. Mark an artifact record invalid when any error directly targets that artifact.
+
+- [ ] **Step 4: Verify the validity gate reports all errors**
+
+Add and run:
+
+```ts
+expect(() => assertValidCatalog(snapshot)).toThrow(CatalogValidationError);
+try {
+  assertValidCatalog(snapshot);
+} catch (error) {
+  expect((error as CatalogValidationError).diagnostics).toHaveLength(snapshot.diagnostics.length);
+}
+```
+
+Run: `npm test -- tests/catalog-snapshot.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit relationship validation**
+
+```bash
+git add src/catalog-snapshot.ts tests/catalog-snapshot.test.ts
+git commit -m "feat: validate catalog artifact relationships"
+```
+
+---
+
+### Task 3: Move catalog compatibility, listing, and doctor to the snapshot
+
+**Files:**
+- Modify: `src/catalog.ts`
+- Create: `src/list-boilerplates-command.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/doctor.ts`
+- Modify: `src/index.ts`
+- Modify: `tests/catalog.test.ts`
+- Create: `tests/cli-list.test.ts`
+- Modify: `tests/doctor.test.ts`
+
+**Interfaces:**
+- Consumes: `loadCatalogSnapshot`, `assertValidCatalog`, `CatalogSnapshot`, and `CatalogDiagnostic`.
+- Produces: compatible `listBoilerplates`/`getBoilerplate`, testable `runListBoilerplates`, and public snapshot exports from `src/index.ts`.
+
+- [ ] **Step 1: Write failing compatibility and list-action tests**
+
+Add custom-root tests showing `getBoilerplate` throws `CatalogValidationError` for a broken catalog. In `tests/cli-list.test.ts`, import from `src/list-boilerplates-command.ts`, create one valid boilerplate plus one malformed boilerplate directory, and inject the loaded snapshot:
+
+```ts
+const stdout: string[] = [];
+const stderr: string[] = [];
+const snapshot = await loadCatalogSnapshot(fixture);
+const exitCode = await runListBoilerplates({
+  loadSnapshot: async () => snapshot,
+  stdout: (line) => stdout.push(line),
+  stderr: (line) => stderr.push(line),
+});
+expect(stdout.join("\n")).toContain("demo");
+expect(stderr.join("\n")).toContain("INVALID_BOILERPLATE_MANIFEST");
+expect(exitCode).toBe(1);
+```
+
+Add a doctor test injecting invalid snapshot roots and expecting a failed `catalog` check containing the diagnostic count.
+
+- [ ] **Step 2: Run focused tests and verify red**
+
+Run: `npm test -- tests/catalog.test.ts tests/cli-list.test.ts tests/doctor.test.ts`
+
+Expected: FAIL because compatibility and list action still use legacy discovery.
+
+- [ ] **Step 3: Replace silent catalog loading**
+
+Implement `catalog.ts` as a compatibility facade:
+
+```ts
+export async function listBoilerplates(
+  boilerplatesDir = defaultBoilerplatesDir(),
+): Promise<Boilerplate[]> {
+  const snapshot = await loadCatalogSnapshot({ boilerplatesDir });
+  assertValidCatalog(snapshot);
+  return [...snapshot.boilerplates];
+}
+
+export async function getBoilerplate(
+  name: string,
+  boilerplatesDir = defaultBoilerplatesDir(),
+): Promise<Boilerplate> {
+  const snapshot = await loadCatalogSnapshot({ boilerplatesDir });
+  assertValidCatalog(snapshot);
+  const match = snapshot.boilerplates.find((boilerplate) => boilerplate.manifest.name === name);
+  if (!match) {
+    const available = snapshot.boilerplates.map((boilerplate) => boilerplate.manifest.name).join(", ") || "(none)";
+    throw new Error(`Unknown boilerplate: "${name}". Available: ${available}.`);
+  }
+  return match;
+}
+```
+
+Keep the current unknown-boilerplate wording.
+
+- [ ] **Step 4: Extract and wire the list action**
+
+Create `src/list-boilerplates-command.ts` with:
+
+```ts
+export interface ListBoilerplatesIo {
+  loadSnapshot: () => Promise<CatalogSnapshot>;
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+}
+
+function renderBoilerplate(boilerplate: CatalogBoilerplate, write: (line: string) => void): void {
+  write(`${boilerplate.manifest.name}  (${boilerplate.manifest.stack})`);
+  write(`  ${boilerplate.manifest.description}`);
+  write(`  skills: ${boilerplate.skills.map((skill) => skill.name).join(", ") || "(none)"}`);
+  if (boilerplate.workflow) write(`  workflow: ${boilerplate.workflow.id}`);
+  write(`  default agents: ${boilerplate.manifest.defaultAgents.join(", ")}`);
+}
+
+export async function runListBoilerplates(io: ListBoilerplatesIo): Promise<0 | 1> {
+  const snapshot = await io.loadSnapshot();
+  for (const boilerplate of snapshot.boilerplates) renderBoilerplate(boilerplate, io.stdout);
+  for (const diagnostic of snapshot.diagnostics) {
+    io.stderr(`${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`);
+  }
+  return snapshot.valid ? 0 : 1;
+}
+```
+
+The Commander action in `src/cli.ts` imports this function, calls it with default roots, and sets `process.exitCode = 1` only when the result is non-zero. Keep all current list output fields.
+
+- [ ] **Step 5: Use snapshot diagnostics in doctor and export public types**
+
+Make the doctor catalog check call `loadCatalogSnapshot`; mark it `fail` when `snapshot.valid` is false and include error count. Preserve `runDoctor(cwd)` and add an optional `runDoctor(cwd, { catalogRoots })` second argument for isolated tests. Export loader, assertion, validation error, and snapshot types from `src/index.ts`.
+
+- [ ] **Step 6: Verify focused and full tests**
+
+Run: `npm test -- tests/catalog.test.ts tests/cli-list.test.ts tests/doctor.test.ts`
+
+Expected: PASS.
+
+Run: `npm test`
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit compatibility migration**
+
+```bash
+git add src/catalog.ts src/list-boilerplates-command.ts src/cli.ts src/doctor.ts src/index.ts tests/catalog.test.ts tests/cli-list.test.ts tests/doctor.test.ts
+git commit -m "refactor: route catalog reads through snapshot"
+```
+
+---
+
+### Task 4: Make catalog scanning consume canonical snapshot skills
+
+**Files:**
+- Modify: `src/catalog-scan.ts`
+- Modify: `tests/catalog-scan.test.ts`
+
+**Interfaces:**
+- Consumes: `CatalogSkill.id`, `CatalogSkill.dir`, `loadCatalogSnapshot`, and `assertValidCatalog`.
+- Produces: scan results whose `id` is `CatalogArtifactIdentity`; no catalog identity originates in the scan module.
+
+- [ ] **Step 1: Write failing scan identity tests**
+
+Replace label-prefix assertions with canonical IDs:
+
+```ts
+const targets = await listCatalogSkillTargets();
+expect(targets.map((target) => target.id)).toContain("shared:code-review");
+expect(targets.some((target) => target.id.startsWith("boilerplate:"))).toBe(true);
+```
+
+Add a broken-catalog fixture and assert `scanCatalog` rejects with `CatalogValidationError` before `scanner.scan` is called.
+
+- [ ] **Step 2: Run the scan tests and verify red**
+
+Run: `npm test -- tests/catalog-scan.test.ts`
+
+Expected: FAIL because current IDs are scanner-specific strings and invalid catalog state is skipped.
+
+- [ ] **Step 3: Reimplement target enumeration as a snapshot projection**
+
+```ts
+export async function listCatalogSkillTargets(
+  opts: Partial<CatalogRoots> = {},
+): Promise<CatalogSkillTarget[]> {
+  const snapshot = await loadCatalogSnapshot(opts);
+  assertValidCatalog(snapshot);
+  return snapshot.skills.map((skill) => ({
+    id: skill.id,
+    label: skill.scope === "shared" ? `shared/${skill.name}` : `boilerplate/${skill.boilerplateName}/${skill.name}`,
+    dir: skill.dir,
+  }));
+}
+```
+
+Update `ScanCatalogOptions` to accept all snapshot roots. Keep labels for human output only. Continue sanitizing canonical IDs only when forming report filenames.
+
+- [ ] **Step 4: Verify and commit**
+
+Run: `npm test -- tests/catalog-scan.test.ts tests/scan.test.ts`
+
+Expected: PASS.
+
+```bash
+git add src/catalog-scan.ts tests/catalog-scan.test.ts
+git commit -m "refactor: scan canonical catalog skills"
+```
+
+---
+
+### Task 5: Migrate registry identity to version 2
+
+**Files:**
+- Modify: `src/registry.ts`
+- Modify: `tests/registry.test.ts`
+- Modify: `tests/upstream-sync.test.ts`
+- Modify: `registry/skills-index.json`
+
+**Interfaces:**
+- Consumes: `CatalogSnapshot` and canonical `CatalogSkill.id`.
+- Produces: `RegistrySkill.id: CatalogArtifactIdentity`, `SkillsIndex.indexVersion: 2`, v1 input migration, and identity-based `findRegistrySkill`/`applyCatalogScanToRegistry`.
+
+- [ ] **Step 1: Write failing version-migration and collision tests**
+
+Add tests that load a minimal v1 registry and assert:
+
+```ts
+const migrated = await loadRegistry(registryPath);
+expect(migrated.indexVersion).toBe(2);
+expect(migrated.skills[0]?.id).toBe("shared:code-review");
+await saveRegistry(migrated, registryPath);
+expect(JSON.parse(await readFile(registryPath, "utf8")).indexVersion).toBe(2);
+```
+
+Add a snapshot fixture with Local Skills named `logger` in two boilerplates and assert both qualified IDs survive registry construction. Add a scan-application test proving results update by `id`, not `bundledIn[0]`.
+
+- [ ] **Step 2: Run registry tests and verify red**
+
+Run: `npm test -- tests/registry.test.ts tests/upstream-sync.test.ts`
+
+Expected: FAIL because only registry version 1 and name lookup exist.
+
+- [ ] **Step 3: Add explicit v1 and v2 schemas**
+
+In `registry.ts`, preserve the old shape as `skillsIndexV1Schema`, define v2 with:
+
+```ts
+const registrySkillV2Schema = registrySkillV1Schema.extend({
+  id: z.string().min(1),
+});
+
+export const skillsIndexSchema = z.object({
+  indexVersion: z.literal(2),
+  updatedAt: z.string(),
+  skills: z.array(registrySkillV2Schema),
+});
+```
+
+`loadRegistry` parses JSON, accepts either schema, and migrates v1 IDs from `catalogLocation`, `catalogPath`, and `bundledIn`. If a local v1 entry cannot identify exactly one boilerplate, throw a migration error naming that entry instead of guessing.
+
+- [ ] **Step 4: Build and update registry by canonical identity**
+
+Delete the `listCatalogSkillTargets` import from `registry.ts`. Change `buildRegistryFromCatalog` to accept an optional `snapshot` and otherwise load/assert one. Iterate `snapshot.skills`; use `skill.id` as the existing-entry map key. Change:
+
+```ts
+export function findRegistrySkill(index: SkillsIndex, id: string): RegistrySkill | undefined {
+  return index.skills.find((skill) => skill.id === id);
+}
+```
+
+Make `applyCatalogScanToRegistry` map scan results by `id`. Remove label reconstruction and `bundledIn[0]` lookup.
+
+- [ ] **Step 5: Regenerate the committed registry**
+
+Run: `npm run build && node dist/cli.js registry-refresh`
+
+Expected: `registry/skills-index.json` has `indexVersion: 2`, every skill has `id`, and local skills have boilerplate-qualified IDs.
+
+- [ ] **Step 6: Verify and commit registry migration**
+
+Run: `npm test -- tests/registry.test.ts tests/catalog-scan.test.ts tests/upstream-sync.test.ts`
+
+Expected: PASS.
+
+```bash
+git add src/registry.ts tests/registry.test.ts tests/upstream-sync.test.ts registry/skills-index.json
+git commit -m "feat: migrate registry to canonical catalog identity"
+```
+
+---
+
+### Task 6: Migrate remaining catalog consumers and remove duplicate resolution
+
+**Files:**
+- Modify: `src/scaffold.ts`
+- Modify: `src/export-plugin.ts`
+- Modify: `src/promote.ts`
+- Modify: `src/sync-skills.ts`
+- Modify: `src/upstream-sync.ts`
+- Modify: `tests/scaffold.test.ts`
+- Modify: `tests/export-plugin.test.ts`
+- Modify: `tests/registry.test.ts`
+- Modify: `tests/upstream-sync.test.ts`
+
+**Interfaces:**
+- Consumes: snapshot-loaded `CatalogBoilerplate.skills`, `CatalogBoilerplate.workflow`, and registry v2 identity.
+- Produces: all catalog workflows operating through the snapshot; no caller invokes `resolveSkillDirectory` to rediscover a declared catalog relationship.
+
+- [ ] **Step 1: Write failing consumer tests against invalid catalogs**
+
+For scaffold and export, use a temporary fixture whose manifest declares a missing skill and assert `CatalogValidationError` before the target directory is written. For sync and promotion, assert invalid pre-existing catalog state blocks mutation. For upstream sync, assert registry lookup uses the shared identity:
+
+```ts
+await expect(scaffold({
+  boilerplateName: "demo",
+  targetDir,
+  agents: ["claude"],
+  catalogRoots: fixture,
+})).rejects.toBeInstanceOf(CatalogValidationError);
+expect(await exists(targetDir)).toBe(false);
+```
+
+Add `catalogRoots?: Partial<CatalogRoots>` to mutation/scaffold/export option types. Preserve existing `boilerplatesDir` and `sharedSkillsDir` fields and merge them into `catalogRoots` so current callers remain compatible.
+
+- [ ] **Step 2: Run consumer tests and verify red**
+
+Run: `npm test -- tests/scaffold.test.ts tests/export-plugin.test.ts tests/registry.test.ts tests/upstream-sync.test.ts`
+
+Expected: FAIL because consumers do not accept or use snapshot roots.
+
+- [ ] **Step 3: Load one validated snapshot before consumer side effects**
+
+At the beginning of scaffold/export/promote/sync operations:
+
+```ts
+const snapshot = await loadCatalogSnapshot({
+  ...options.catalogRoots,
+  ...(options.boilerplatesDir ? { boilerplatesDir: options.boilerplatesDir } : {}),
+});
+assertValidCatalog(snapshot);
+const boilerplate = snapshot.boilerplates.find((entry) => entry.manifest.name === boilerplateName);
+if (!boilerplate) {
+  const available = snapshot.boilerplates.map((entry) => entry.manifest.name).join(", ") || "(none)";
+  throw new Error(`Unknown boilerplate: "${boilerplateName}". Available: ${available}.`);
+}
+```
+
+Use `boilerplate.skills[].dir` when copying or packaging skills and `boilerplate.workflow?.dir` when copying workflows. Validate before creating output directories or copying catalog artifacts.
+
+- [ ] **Step 4: Move sync and upstream lookups to identity**
+
+For shared registry entries, use `shared:${skill.name}`. Preserve CLI `--skill <name>` as a display-name convenience but resolve it only among Shared Skills; throw an ambiguity error if future data produces more than one match. When a mutation needs a post-write registry rebuild, load a new snapshot and assert it before saving registry v2.
+
+- [ ] **Step 5: Remove obsolete relationship reconstruction**
+
+Delete caller imports of `resolveSkillDirectory`, `resolveWorkflowDirectory`, and scanner labels where they are no longer needed. Keep `skills.ts` and `workflows.ts` functions only if a remaining non-snapshot caller genuinely uses them; otherwise delete the unused exports and update `src/index.ts`.
+
+- [ ] **Step 6: Verify consumer tests and the whole suite**
+
+Run: `npm test -- tests/scaffold.test.ts tests/export-plugin.test.ts tests/registry.test.ts tests/upstream-sync.test.ts tests/catalog.test.ts`
+
+Expected: PASS.
+
+Run: `npm test && npm run typecheck && npm run lint`
+
+Expected: all commands exit 0.
+
+- [ ] **Step 7: Commit consumer migration**
+
+```bash
+git add src tests
+git commit -m "refactor: consume validated catalog snapshots"
+```
+
+---
+
+### Task 7: Document the seam and run release-level verification
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `README.md` only if command output or maintainer instructions changed.
+
+**Interfaces:**
+- Consumes: completed snapshot and registry v2 behavior.
+- Produces: documented artifact identities, validation scope, diagnostics behavior, and verified release artifacts.
+
+- [ ] **Step 1: Update architecture documentation**
+
+Add a “Catalog Snapshot” section to `docs/ARCHITECTURE.md` containing:
+
+```md
+## Catalog Snapshot
+
+Every catalog reader loads one immutable snapshot of boilerplates, skills, and workflows. The snapshot assigns scope-qualified identities, validates metadata and relationships, and accumulates diagnostics before strict commands perform work.
+
+`list-boilerplates` prints valid entries plus diagnostics and exits non-zero for an invalid catalog. SkillSpector and runnable-template checks remain separate gates.
+```
+
+Document registry version 2 identity examples and the v1 read-migration guarantee.
+
+- [ ] **Step 2: Run the complete repository verification**
+
+Run:
+
+```bash
+npm test
+npm run typecheck
+npm run lint
+npm run build
+node dist/cli.js list-boilerplates
+node dist/cli.js doctor
+npm pack --dry-run --cache /tmp/bwai-catalog-snapshot-npm-cache
+```
+
+Expected:
+
+- Vitest reports all test files and tests passing.
+- TypeScript exits 0.
+- Prettier reports all matched files formatted.
+- `tsup` builds `dist/cli.js` successfully.
+- `list-boilerplates` lists all seven current boilerplates and exits 0.
+- Doctor reports the catalog check as `ok`.
+- Package dry-run includes `dist`, `boilerplates`, `shared`, and registry version 2.
+
+- [ ] **Step 3: Confirm no legacy identity reconstruction remains**
+
+Run:
+
+```bash
+rg 'target\.dir\.split|label\.startsWith|bundledIn\[0\]' src tests
+rg 'listCatalogSkillTargets' src/registry.ts
+```
+
+Expected: both commands return no matches.
+
+- [ ] **Step 4: Review the final diff against the design**
+
+Run: `git diff --check && git status --short`
+
+Expected: no whitespace errors; only intended snapshot, consumer, registry, tests, and documentation files are changed.
+
+- [ ] **Step 5: Commit documentation and final cleanup**
+
+```bash
+git add docs/ARCHITECTURE.md README.md
+git commit -m "docs: explain validated catalog snapshots"
+```
+
+- [ ] **Step 6: Request code review**
+
+Use the `requesting-code-review` skill against the design and this implementation plan. Address correctness findings before branch integration.

--- a/docs/superpowers/specs/2026-08-24-catalog-snapshot-design.md
+++ b/docs/superpowers/specs/2026-08-24-catalog-snapshot-design.md
@@ -1,0 +1,222 @@
+# Validated Catalog Snapshot Design
+
+**Date:** 2026-08-24
+**Status:** Approved design
+
+## Purpose
+
+Replace fragmented catalog discovery with one immutable, validated Catalog Snapshot. Every catalog reader will share the same artifact identities, relationships, and diagnostics instead of reconstructing them from paths, labels, or partial directory walks.
+
+## Problem
+
+Catalog knowledge is currently spread across `catalog.ts`, `catalog-scan.ts`, `registry.ts`, `skills.ts`, and `workflows.ts`:
+
+- `listBoilerplates` silently skips directories whose manifest is missing or invalid.
+- Catalog scan invents string IDs and display labels that registry code later parses to recover identity.
+- Registry construction derives skill names from filesystem separators and maps local scan results through `bundledIn[0]`.
+- Declared and physical artifacts are validated independently by different callers.
+- Boilerplate-local skill directories can exist without a manifest declaration.
+- A local and shared skill with the same short name can collide at scaffold installation paths even though their catalog scopes differ.
+
+This produces a shallow discovery interface: callers must understand filesystem layout, scope rules, identity encoding, and error behavior.
+
+## Domain Decisions
+
+The canonical language is recorded in `CONTEXT.md`.
+
+### Complete snapshot with diagnostics
+
+Loading returns a complete snapshot and accumulates all expected catalog problems as structured diagnostics. It does not fail at the first invalid artifact, and invalid discoveries remain represented in the snapshot.
+
+Strict consumers reject a snapshot containing error diagnostics. `list-boilerplates` still prints valid boilerplates and diagnostics, then exits non-zero.
+
+### Catalog validation scope
+
+The snapshot validates catalog metadata and relationships:
+
+- Manifest JSON and schema
+- Directory and manifest name consistency
+- Declared artifact existence
+- Skill frontmatter compliance
+- Workflow metadata structure and declared workflow identity
+- Duplicate identities and declarations
+- Local-skill ownership
+- Per-boilerplate install-name uniqueness
+
+The snapshot does not run SkillSpector, execute generated projects, install dependencies, or test templates. Those remain separate gates.
+
+Workflow metadata validation initially requires:
+
+- Non-empty `schemaVersion`, `name`, `version`, and `description` strings
+- A lowercase-hyphen-case workflow `name`
+- A `skills` array whose entries contain a non-empty `source` and optional string `repo`
+- A `steps` array whose entries contain non-empty `id`, `title`, and `skill` strings plus an optional string `gate`
+- Unique step IDs
+- A workflow name matching its manifest declaration and, for shared workflows, its directory name
+
+### Artifact identity
+
+Canonical skill identity is scope-qualified:
+
+- Shared Skill: `shared:<skill-name>`
+- Local Skill: `boilerplate:<boilerplate-name>/skills/<skill-name>`
+
+Other Catalog Artifacts use:
+
+- Boilerplate: `boilerplate:<boilerplate-name>`
+- Shared workflow: `shared:workflows/<workflow-name>`
+- Local workflow: `boilerplate:<boilerplate-name>/workflow/<workflow-name>`
+
+Short names and labels are presentation fields, not identity. Two boilerplates may own different Local Skills with the same short name. A single boilerplate may not declare a Local Skill and Shared Skill with the same short name because both install to the same destination.
+
+The directory `boilerplates/<name>` and the manifest's `name` field must match exactly.
+
+### Local and shared ownership
+
+A Local Skill has exactly one owning boilerplate and must be declared by that boilerplate. An undeclared Local Skill is an error.
+
+A Shared Skill may exist without being bundled by any boilerplate.
+
+### Snapshot lifecycle
+
+Snapshots are immutable and are not cached across operations. Each catalog read phase loads a fresh snapshot. A mutation command may load a second snapshot after writing to validate the resulting catalog state.
+
+## Architecture
+
+### New deep module
+
+Add `src/catalog-snapshot.ts`. It owns:
+
+1. Filesystem discovery beneath configurable catalog roots.
+2. Metadata parsing for each discovered artifact.
+3. Canonical identity construction.
+4. Index construction and duplicate detection.
+5. Manifest-to-artifact relationship resolution.
+6. Deterministic Catalog Diagnostic creation.
+
+The module exposes a small interface for loading a snapshot, inspecting artifacts and diagnostics, reading valid artifact collections, and asserting validity.
+
+Its implementation may use existing parsing and path helpers internally, but callers must not need filesystem-layout knowledge to consume the snapshot.
+
+### Snapshot data
+
+The immutable Catalog Snapshot contains:
+
+- Every discovered artifact record, including invalid records
+- Valid boilerplates indexed by boilerplate name
+- Valid skills indexed by Catalog Artifact Identity
+- Valid workflows indexed by Catalog Artifact Identity
+- A deterministically ordered list of Catalog Diagnostics
+- A validity value derived from the absence of error diagnostics
+
+Each discovered artifact record includes its kind, source path, validation state, and canonical identity when one can be derived safely.
+
+Each diagnostic includes:
+
+- Stable diagnostic code
+- Severity
+- Artifact kind
+- Source path
+- Canonical identity when known
+- Human-readable message
+
+Expected catalog problems become diagnostics. Unexpected programming failures may still throw.
+
+### Initial diagnostic set
+
+The initial error codes cover:
+
+- Missing or unreadable catalog root
+- Invalid manifest JSON or schema
+- Boilerplate directory/name mismatch
+- Duplicate artifact identity
+- Missing template directory
+- Missing or invalid declared skill
+- Undeclared Local Skill
+- Duplicate skill declaration
+- Per-boilerplate skill install-name collision
+- Missing or invalid workflow metadata
+
+Stable codes are part of the snapshot interface; prose messages are not.
+
+## Loading Flow
+
+Snapshot loading runs four deterministic phases:
+
+1. **Discover:** enumerate candidate artifact paths in sorted order.
+2. **Parse:** parse each artifact independently and retain invalid records.
+3. **Index:** assign canonical identities and detect duplicates or name mismatches.
+4. **Relate:** resolve manifest declarations and detect missing, conflicting, or undeclared artifacts.
+
+Diagnostics are sorted deterministically by source path, then diagnostic code. This keeps CLI output and tests stable across platforms.
+
+Portable path operations must use `node:path` helpers. Identity must never be derived by splitting on `/` or parsing display labels.
+
+## Consumer Migration
+
+Migrate consumers in this order:
+
+1. Make `catalog.ts` delegate existing list/get behavior to the snapshot.
+2. Make catalog scanning enumerate snapshot skills and carry canonical identity in results.
+3. Make registry construction consume snapshot artifacts directly.
+4. Move scaffold, plugin export, doctor, promotion, and synchronization to snapshot-derived relationships.
+5. Remove scanner-specific catalog discovery and legacy identity reconstruction after the last consumer migrates.
+
+`listBoilerplates` and `getBoilerplate` remain exported for compatibility. They no longer silently hide invalid catalog state. Strict domain workflows assert snapshot validity before performing their work.
+
+## Registry Migration
+
+Increment `registry/skills-index.json` to `indexVersion: 2`.
+
+Version 2 skill entries include canonical identity and retain `name` as a display field. Registry lookup and scan-result application use canonical identity.
+
+The registry loader accepts version 1 and migrates it in memory. A subsequent save always writes version 2. The committed registry is regenerated as version 2 during implementation.
+
+## Error Presentation
+
+Strict CLI commands print every Catalog Diagnostic error to stderr and exit non-zero before domain work begins.
+
+`list-boilerplates` is the exception for output behavior: it prints valid boilerplates to stdout, prints diagnostics to stderr, and exits non-zero when errors exist. This preserves useful discovery without representing a partial catalog as healthy.
+
+## Testing
+
+Use temporary catalog fixtures to verify the snapshot interface rather than private parsing functions.
+
+Required cases:
+
+- Multiple independent diagnostics collected in one load
+- Invalid artifacts retained as discovery records
+- Directory and manifest name mismatch
+- Missing declared skill
+- Missing declared workflow
+- Invalid skill frontmatter
+- Invalid workflow metadata
+- Undeclared Local Skill
+- Duplicate declaration
+- Local/Shared Skill install-name collision
+- Same Local Skill short name in different boilerplates remains valid
+- Deterministic diagnostic ordering
+- Portable identity construction without path-string splitting
+- Partial `list-boilerplates` output with a non-zero exit status
+- Registry version 1 migration and version 2 persistence
+- Existing scaffold, scan, export, promotion, and synchronization behavior
+
+The full repository test, typecheck, lint, build, CLI smoke, and package dry-run checks must pass.
+
+## Out of Scope
+
+- Transactional catalog writes or rollback
+- SkillSpector policy consolidation
+- Agent Plugin regeneration fixes
+- Executing or dependency-installing scaffolded templates
+- Watch mode or persistent snapshot caching
+- A general filesystem seam without a second adapter
+
+## Completion Criteria
+
+- No catalog consumer reconstructs identity from labels or path separators.
+- Invalid catalog artifacts cannot disappear silently.
+- Strict commands report all catalog errors before domain work.
+- Read-only listing preserves useful partial output and fails visibly.
+- Registry version 1 loads and version 2 saves.
+- All existing behavior remains covered and the full verification suite passes.

--- a/registry/skills-index.json
+++ b/registry/skills-index.json
@@ -1,7 +1,121 @@
 {
-  "indexVersion": 1,
-  "updatedAt": "2026-08-10T03:04:01.782Z",
+  "indexVersion": 2,
+  "updatedAt": "2026-08-24T06:11:56.387Z",
   "skills": [
+    {
+      "name": "express-api-design",
+      "catalogLocation": "local",
+      "catalogPath": "boilerplates/express-api/skills/express-api-design",
+      "description": "Use when adding or changing routes, middleware, or error handling in this Express.js API, to keep endpoints consistent, validated, and testable.",
+      "promotedAt": "2026-07-05T03:00:00.000Z",
+      "sha256": "843c10d094c1d26ae3820f360cbde519a1dbe5016b9c364067132e39de3af5d9",
+      "scan": {
+        "status": "passed",
+        "riskScore": 0,
+        "scannedAt": "2026-07-05T02:45:00.000Z",
+        "threshold": 30
+      },
+      "bundleAll": false,
+      "bundledIn": [
+        "express-api"
+      ],
+      "id": "boilerplate:express-api/skills/express-api-design"
+    },
+    {
+      "name": "fastify-api-design",
+      "catalogLocation": "local",
+      "catalogPath": "boilerplates/fastify-api/skills/fastify-api-design",
+      "description": "Use when adding or changing routes, schemas, or plugins in this Fastify API — keep endpoints validated, typed, and testable.",
+      "promotedAt": "2026-07-05T07:17:52.632Z",
+      "sha256": "7eccae8f243e123544d0309df5c8d18ddeef53757343c30af8c206da94a74c25",
+      "scan": {
+        "status": "pending",
+        "riskScore": null,
+        "scannedAt": null,
+        "threshold": 30
+      },
+      "bundleAll": false,
+      "bundledIn": [
+        "fastify-api"
+      ],
+      "id": "boilerplate:fastify-api/skills/fastify-api-design"
+    },
+    {
+      "name": "nextjs-ai-sdk",
+      "catalogLocation": "local",
+      "catalogPath": "boilerplates/nextjs-ai-app/skills/nextjs-ai-sdk",
+      "description": "Use when adding chat routes, LLM tools, structured outputs, or streaming UI with the Vercel AI SDK in this Next.js AI app.",
+      "promotedAt": "2026-07-16T09:48:00.000Z",
+      "sha256": "c7676103215e1ebccb25880461d5c9dae5fecee53b1abe35dfbe7a16d81523a4",
+      "scan": {
+        "status": "pending",
+        "riskScore": null,
+        "scannedAt": null,
+        "threshold": 30
+      },
+      "bundleAll": false,
+      "bundledIn": [
+        "nextjs-ai-app"
+      ],
+      "id": "boilerplate:nextjs-ai-app/skills/nextjs-ai-sdk"
+    },
+    {
+      "name": "nextjs-app-router",
+      "catalogLocation": "local",
+      "catalogPath": "boilerplates/nextjs-app/skills/nextjs-app-router",
+      "description": "Use when adding pages, layouts, route handlers, or data fetching in this Next.js App Router project, to follow server-first conventions correctly.",
+      "promotedAt": "2026-07-05T03:00:00.000Z",
+      "sha256": "766cefae14cb11b9e936c4447226d6fffac8b57e033afcea6dd73fc428656391",
+      "scan": {
+        "status": "passed",
+        "riskScore": 0,
+        "scannedAt": "2026-07-05T02:45:00.000Z",
+        "threshold": 30
+      },
+      "bundleAll": false,
+      "bundledIn": [
+        "nextjs-app"
+      ],
+      "id": "boilerplate:nextjs-app/skills/nextjs-app-router"
+    },
+    {
+      "name": "python-api-design",
+      "catalogLocation": "local",
+      "catalogPath": "boilerplates/python-service/skills/python-api-design",
+      "description": "Use when adding or changing FastAPI routes, dependencies, or tests in this Python service — keep endpoints typed, validated, and covered by pytest.",
+      "promotedAt": "2026-07-05T07:17:52.632Z",
+      "sha256": "0290156bf22870208ea54dd861fcf3b0fa8a6dee5d83c9e2475fd7eb418b3b1a",
+      "scan": {
+        "status": "pending",
+        "riskScore": null,
+        "scannedAt": null,
+        "threshold": 30
+      },
+      "bundleAll": false,
+      "bundledIn": [
+        "python-service"
+      ],
+      "id": "boilerplate:python-service/skills/python-api-design"
+    },
+    {
+      "name": "react-native-development",
+      "catalogLocation": "local",
+      "catalogPath": "boilerplates/react-native-app/skills/react-native-development",
+      "description": "Use when building screens, navigation, styling, or platform behavior in this Expo React Native app, to follow mobile-first conventions and keep logic testable.",
+      "promotedAt": "2026-07-05T03:00:00.000Z",
+      "sha256": "384107428604c954a4c132d4b4959a80653662f7ee7cc5354fa343c3b46046aa",
+      "scan": {
+        "status": "passed",
+        "riskScore": 0,
+        "scannedAt": "2026-07-05T02:45:00.000Z",
+        "threshold": 30
+      },
+      "bundleAll": false,
+      "bundledIn": [
+        "react-native-app"
+      ],
+      "id": "boilerplate:react-native-app/skills/react-native-development"
+    },
     {
       "name": "bwai-advisor",
       "catalogLocation": "shared",
@@ -16,7 +130,8 @@
         "threshold": 30
       },
       "bundleAll": false,
-      "bundledIn": []
+      "bundledIn": [],
+      "id": "shared:bwai-advisor"
     },
     {
       "name": "code-review",
@@ -42,7 +157,8 @@
         "nextjs-app",
         "node-service",
         "python-service"
-      ]
+      ],
+      "id": "shared:code-review"
     },
     {
       "name": "cto",
@@ -71,7 +187,8 @@
         "node-service",
         "python-service",
         "react-native-app"
-      ]
+      ],
+      "id": "shared:cto"
     },
     {
       "name": "deploy-vercel",
@@ -91,43 +208,8 @@
         "express-api",
         "nextjs-ai-app",
         "nextjs-app"
-      ]
-    },
-    {
-      "name": "express-api-design",
-      "catalogLocation": "local",
-      "catalogPath": "boilerplates/express-api/skills/express-api-design",
-      "description": "Use when adding or changing routes, middleware, or error handling in this Express.js API, to keep endpoints consistent, validated, and testable.",
-      "promotedAt": "2026-07-05T03:00:00.000Z",
-      "sha256": "843c10d094c1d26ae3820f360cbde519a1dbe5016b9c364067132e39de3af5d9",
-      "scan": {
-        "status": "passed",
-        "riskScore": 0,
-        "scannedAt": "2026-07-05T02:45:00.000Z",
-        "threshold": 30
-      },
-      "bundleAll": false,
-      "bundledIn": [
-        "express-api"
-      ]
-    },
-    {
-      "name": "fastify-api-design",
-      "catalogLocation": "local",
-      "catalogPath": "boilerplates/fastify-api/skills/fastify-api-design",
-      "description": "Use when adding or changing routes, schemas, or plugins in this Fastify API — keep endpoints validated, typed, and testable.",
-      "promotedAt": "2026-07-05T07:17:52.632Z",
-      "sha256": "7eccae8f243e123544d0309df5c8d18ddeef53757343c30af8c206da94a74c25",
-      "scan": {
-        "status": "pending",
-        "riskScore": null,
-        "scannedAt": null,
-        "threshold": 30
-      },
-      "bundleAll": false,
-      "bundledIn": [
-        "fastify-api"
-      ]
+      ],
+      "id": "shared:deploy-vercel"
     },
     {
       "name": "founding-engineer",
@@ -156,43 +238,8 @@
         "node-service",
         "python-service",
         "react-native-app"
-      ]
-    },
-    {
-      "name": "nextjs-ai-sdk",
-      "catalogLocation": "local",
-      "catalogPath": "boilerplates/nextjs-ai-app/skills/nextjs-ai-sdk",
-      "description": "Use when adding chat routes, LLM tools, structured outputs, or streaming UI with the Vercel AI SDK in this Next.js AI app.",
-      "promotedAt": "2026-07-16T09:48:00.000Z",
-      "sha256": "c7676103215e1ebccb25880461d5c9dae5fecee53b1abe35dfbe7a16d81523a4",
-      "scan": {
-        "status": "pending",
-        "riskScore": null,
-        "scannedAt": null,
-        "threshold": 30
-      },
-      "bundleAll": false,
-      "bundledIn": [
-        "nextjs-ai-app"
-      ]
-    },
-    {
-      "name": "nextjs-app-router",
-      "catalogLocation": "local",
-      "catalogPath": "boilerplates/nextjs-app/skills/nextjs-app-router",
-      "description": "Use when adding pages, layouts, route handlers, or data fetching in this Next.js App Router project, to follow server-first conventions correctly.",
-      "promotedAt": "2026-07-05T03:00:00.000Z",
-      "sha256": "766cefae14cb11b9e936c4447226d6fffac8b57e033afcea6dd73fc428656391",
-      "scan": {
-        "status": "passed",
-        "riskScore": 0,
-        "scannedAt": "2026-07-05T02:45:00.000Z",
-        "threshold": 30
-      },
-      "bundleAll": false,
-      "bundledIn": [
-        "nextjs-app"
-      ]
+      ],
+      "id": "shared:founding-engineer"
     },
     {
       "name": "product-manager",
@@ -221,7 +268,8 @@
         "node-service",
         "python-service",
         "react-native-app"
-      ]
+      ],
+      "id": "shared:product-manager"
     },
     {
       "name": "project-security",
@@ -245,25 +293,8 @@
         "node-service",
         "python-service",
         "react-native-app"
-      ]
-    },
-    {
-      "name": "python-api-design",
-      "catalogLocation": "local",
-      "catalogPath": "boilerplates/python-service/skills/python-api-design",
-      "description": "Use when adding or changing FastAPI routes, dependencies, or tests in this Python service — keep endpoints typed, validated, and covered by pytest.",
-      "promotedAt": "2026-07-05T07:17:52.632Z",
-      "sha256": "0290156bf22870208ea54dd861fcf3b0fa8a6dee5d83c9e2475fd7eb418b3b1a",
-      "scan": {
-        "status": "pending",
-        "riskScore": null,
-        "scannedAt": null,
-        "threshold": 30
-      },
-      "bundleAll": false,
-      "bundledIn": [
-        "python-service"
-      ]
+      ],
+      "id": "shared:project-security"
     },
     {
       "name": "qa-lead",
@@ -292,25 +323,8 @@
         "node-service",
         "python-service",
         "react-native-app"
-      ]
-    },
-    {
-      "name": "react-native-development",
-      "catalogLocation": "local",
-      "catalogPath": "boilerplates/react-native-app/skills/react-native-development",
-      "description": "Use when building screens, navigation, styling, or platform behavior in this Expo React Native app, to follow mobile-first conventions and keep logic testable.",
-      "promotedAt": "2026-07-05T03:00:00.000Z",
-      "sha256": "384107428604c954a4c132d4b4959a80653662f7ee7cc5354fa343c3b46046aa",
-      "scan": {
-        "status": "passed",
-        "riskScore": 0,
-        "scannedAt": "2026-07-05T02:45:00.000Z",
-        "threshold": 30
-      },
-      "bundleAll": false,
-      "bundledIn": [
-        "react-native-app"
-      ]
+      ],
+      "id": "shared:qa-lead"
     },
     {
       "name": "startup-goal",
@@ -339,7 +353,8 @@
         "node-service",
         "python-service",
         "react-native-app"
-      ]
+      ],
+      "id": "shared:startup-goal"
     },
     {
       "name": "test-driven-development",
@@ -366,7 +381,8 @@
         "node-service",
         "python-service",
         "react-native-app"
-      ]
+      ],
+      "id": "shared:test-driven-development"
     }
   ]
 }

--- a/src/catalog-scan.ts
+++ b/src/catalog-scan.ts
@@ -1,18 +1,23 @@
-import { readdir, stat, mkdir, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { listBoilerplates } from "./catalog.js";
-import { defaultBoilerplatesDir, defaultSharedSkillsDir, packageRoot } from "./paths.js";
+import { packageRoot } from "./paths.js";
 import { scanSkillDirectory, type SkillScanner, type ScanResult } from "./scan.js";
+import {
+  assertValidCatalog,
+  loadCatalogSnapshot,
+  type CatalogArtifactIdentity,
+  type CatalogRoots,
+} from "./catalog-snapshot.js";
 
 export interface CatalogSkillTarget {
-  id: string;
+  id: CatalogArtifactIdentity;
   label: string;
   dir: string;
 }
 
 export interface CatalogScanResult {
   name: string;
-  id: string;
+  id: CatalogArtifactIdentity;
   riskScore: number | null;
   status: "passed" | "failed" | "skipped";
   findings: number;
@@ -26,53 +31,20 @@ export interface CatalogScanReport {
   results: CatalogScanResult[];
 }
 
-async function isSkillDirectory(path: string): Promise<boolean> {
-  try {
-    return (await stat(path)).isDirectory() && (await stat(join(path, "SKILL.md"))).isFile();
-  } catch {
-    return false;
-  }
-}
-
 /** Discover every skill directory shipped in this catalog repo. */
 export async function listCatalogSkillTargets(
-  opts: { boilerplatesDir?: string; sharedSkillsDir?: string } = {},
+  opts: Partial<CatalogRoots> = {},
 ): Promise<CatalogSkillTarget[]> {
-  const sharedDir = opts.sharedSkillsDir ?? defaultSharedSkillsDir();
-  const boilerplatesDir = opts.boilerplatesDir ?? defaultBoilerplatesDir();
-  const targets: CatalogSkillTarget[] = [];
-
-  try {
-    for (const name of (await readdir(sharedDir)).sort()) {
-      const dir = join(sharedDir, name);
-      if (await isSkillDirectory(dir)) {
-        targets.push({ id: `shared-${name}`, label: `shared/${name}`, dir });
-      }
-    }
-  } catch {
-    // no shared dir
-  }
-
-  for (const bp of await listBoilerplates(boilerplatesDir)) {
-    let entries: string[] = [];
-    try {
-      entries = await readdir(bp.skillsDir);
-    } catch {
-      continue;
-    }
-    for (const name of entries.sort()) {
-      const dir = join(bp.skillsDir, name);
-      if (await isSkillDirectory(dir)) {
-        targets.push({
-          id: `${bp.manifest.name}-${name}`,
-          label: `boilerplate/${bp.manifest.name}/${name}`,
-          dir,
-        });
-      }
-    }
-  }
-
-  return targets;
+  const snapshot = await loadCatalogSnapshot(opts);
+  assertValidCatalog(snapshot);
+  return snapshot.skills.map((skill) => ({
+    id: skill.id,
+    label:
+      skill.scope === "shared"
+        ? `shared/${skill.name}`
+        : `boilerplate/${skill.boilerplateName}/${skill.name}`,
+    dir: skill.dir,
+  }));
 }
 
 function safeReportBasename(id: string): string {
@@ -87,6 +59,7 @@ export interface ScanCatalogOptions {
   reportsDir?: string;
   boilerplatesDir?: string;
   sharedSkillsDir?: string;
+  sharedWorkflowsDir?: string;
 }
 
 export async function scanCatalog(options: ScanCatalogOptions): Promise<CatalogScanReport> {

--- a/src/catalog-snapshot.ts
+++ b/src/catalog-snapshot.ts
@@ -1,8 +1,9 @@
-import { readdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { basename, join } from "node:path";
 import {
   boilerplateManifestSchema,
   type BoilerplateManifest,
+  workflowManifestSchema,
   type WorkflowManifest,
 } from "./schema.js";
 import { assertSkillCompliant } from "./skill-frontmatter.js";
@@ -104,7 +105,11 @@ export function assertValidCatalog(snapshot: CatalogSnapshot): void {
   if (errors.length > 0) throw new CatalogValidationError(errors);
 }
 
-async function directoryNames(root: string, diagnostics: CatalogDiagnostic[]): Promise<string[]> {
+async function directoryNames(
+  root: string,
+  diagnostics: CatalogDiagnostic[],
+  required = true,
+): Promise<string[]> {
   try {
     const entries = await readdir(root, { withFileTypes: true });
     return entries
@@ -112,6 +117,7 @@ async function directoryNames(root: string, diagnostics: CatalogDiagnostic[]): P
       .map((entry) => entry.name)
       .sort();
   } catch (error) {
+    if (!required && (error as NodeJS.ErrnoException).code === "ENOENT") return [];
     diagnostics.push({
       code: "CATALOG_ROOT_UNREADABLE",
       severity: "error",
@@ -120,6 +126,67 @@ async function directoryNames(root: string, diagnostics: CatalogDiagnostic[]): P
       message: error instanceof Error ? error.message : String(error),
     });
     return [];
+  }
+}
+
+async function loadSkill(
+  dir: string,
+  id: CatalogArtifactIdentity,
+  scope: "shared" | "local",
+  diagnostics: CatalogDiagnostic[],
+  boilerplateName?: string,
+): Promise<{ skill?: CatalogSkill; artifact: CatalogArtifactRecord }> {
+  const name = basename(dir);
+  try {
+    const content = await readFile(join(dir, "SKILL.md"), "utf8");
+    assertSkillCompliant(content, { directoryName: name, requireEnrichment: true });
+    return {
+      skill: { id, name, scope, dir, boilerplateName },
+      artifact: { kind: "skill", path: dir, identity: id, valid: true },
+    };
+  } catch (error) {
+    diagnostics.push({
+      code: "INVALID_SKILL_METADATA",
+      severity: "error",
+      kind: "skill",
+      path: dir,
+      identity: id,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return { artifact: { kind: "skill", path: dir, identity: id, valid: false } };
+  }
+}
+
+async function loadWorkflow(
+  dir: string,
+  id: CatalogArtifactIdentity,
+  scope: "shared" | "local",
+  diagnostics: CatalogDiagnostic[],
+  boilerplateName?: string,
+): Promise<{ workflow?: CatalogWorkflow; artifact: CatalogArtifactRecord }> {
+  const directoryName = basename(dir);
+  try {
+    const raw = await readFile(join(dir, "workflow.json"), "utf8");
+    const manifest = workflowManifestSchema.parse(JSON.parse(raw));
+    if (manifest.name !== directoryName) {
+      throw new Error(
+        `workflow name "${manifest.name}" must match directory name "${directoryName}"`,
+      );
+    }
+    return {
+      workflow: { id, name: manifest.name, scope, dir, manifest, boilerplateName },
+      artifact: { kind: "workflow", path: dir, identity: id, valid: true },
+    };
+  } catch (error) {
+    diagnostics.push({
+      code: "INVALID_WORKFLOW_METADATA",
+      severity: "error",
+      kind: "workflow",
+      path: dir,
+      identity: id,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return { artifact: { kind: "workflow", path: dir, identity: id, valid: false } };
   }
 }
 
@@ -153,58 +220,91 @@ export async function loadCatalogSnapshot(
   const artifacts: CatalogArtifactRecord[] = [];
   const skills: CatalogSkill[] = [];
   const workflows: CatalogWorkflow[] = [];
-  const boilerplates: CatalogBoilerplate[] = [];
+  const discoveredBoilerplates: CatalogBoilerplate[] = [];
 
-  const sharedSkillNames = await directoryNames(roots.sharedSkillsDir, diagnostics);
-  for (const name of sharedSkillNames) {
+  for (const name of await directoryNames(roots.sharedSkillsDir, diagnostics)) {
     const dir = join(roots.sharedSkillsDir, name);
-    const id = `shared:${name}` as const;
-    try {
-      const content = await readFile(join(dir, "SKILL.md"), "utf8");
-      assertSkillCompliant(content, { directoryName: name, requireEnrichment: true });
-      skills.push({ id, name, scope: "shared", dir });
-      artifacts.push({ kind: "skill", path: dir, identity: id, valid: true });
-    } catch (error) {
-      diagnostics.push({
-        code: "INVALID_SKILL_METADATA",
-        severity: "error",
-        kind: "skill",
-        path: dir,
-        identity: id,
-        message: error instanceof Error ? error.message : String(error),
-      });
-      artifacts.push({ kind: "skill", path: dir, identity: id, valid: false });
-    }
+    const loaded = await loadSkill(dir, `shared:${name}`, "shared", diagnostics);
+    if (loaded.skill) skills.push(loaded.skill);
+    artifacts.push(loaded.artifact);
   }
 
-  await directoryNames(roots.sharedWorkflowsDir, diagnostics);
-  const boilerplateDirectories = await directoryNames(roots.boilerplatesDir, diagnostics);
-  for (const directoryName of boilerplateDirectories) {
+  for (const name of await directoryNames(roots.sharedWorkflowsDir, diagnostics)) {
+    const dir = join(roots.sharedWorkflowsDir, name);
+    const loaded = await loadWorkflow(dir, `shared:workflows/${name}`, "shared", diagnostics);
+    if (loaded.workflow) workflows.push(loaded.workflow);
+    artifacts.push(loaded.artifact);
+  }
+
+  for (const directoryName of await directoryNames(roots.boilerplatesDir, diagnostics)) {
     const dir = join(roots.boilerplatesDir, directoryName);
     try {
       const raw = await readFile(join(dir, "boilerplate.json"), "utf8");
       const manifest = boilerplateManifestSchema.parse(JSON.parse(raw));
       const id = `boilerplate:${manifest.name}` as const;
-      const resolvedSkills = manifest.skills
-        .map((ref) =>
-          skills.find(
-            (skill) =>
-              skill.id ===
-              (ref.source === "shared"
-                ? `shared:${ref.name}`
-                : `boilerplate:${manifest.name}/skills/${ref.name}`),
-          ),
-        )
-        .filter((skill): skill is CatalogSkill => Boolean(skill));
-      boilerplates.push({
+      let valid = true;
+      if (manifest.name !== directoryName) {
+        valid = false;
+        diagnostics.push({
+          code: "BOILERPLATE_NAME_MISMATCH",
+          severity: "error",
+          kind: "boilerplate",
+          path: dir,
+          identity: id,
+          message: `manifest name "${manifest.name}" must match directory name "${directoryName}"`,
+        });
+      }
+
+      const templateDir = join(dir, "template");
+      try {
+        if (!(await stat(templateDir)).isDirectory()) throw new Error("not a directory");
+      } catch {
+        valid = false;
+        diagnostics.push({
+          code: "MISSING_TEMPLATE",
+          severity: "error",
+          kind: "boilerplate",
+          path: templateDir,
+          identity: id,
+          message: `Template directory not found: ${templateDir}`,
+        });
+      }
+
+      for (const name of await directoryNames(join(dir, "skills"), diagnostics, false)) {
+        const skillDir = join(dir, "skills", name);
+        const loaded = await loadSkill(
+          skillDir,
+          `boilerplate:${manifest.name}/skills/${name}`,
+          "local",
+          diagnostics,
+          manifest.name,
+        );
+        if (loaded.skill) skills.push(loaded.skill);
+        artifacts.push(loaded.artifact);
+      }
+
+      for (const name of await directoryNames(join(dir, "workflow"), diagnostics, false)) {
+        const workflowDir = join(dir, "workflow", name);
+        const loaded = await loadWorkflow(
+          workflowDir,
+          `boilerplate:${manifest.name}/workflow/${name}`,
+          "local",
+          diagnostics,
+          manifest.name,
+        );
+        if (loaded.workflow) workflows.push(loaded.workflow);
+        artifacts.push(loaded.artifact);
+      }
+
+      discoveredBoilerplates.push({
         id,
         manifest,
         dir,
-        templateDir: join(dir, "template"),
+        templateDir,
         skillsDir: join(dir, "skills"),
-        skills: resolvedSkills,
+        skills: [],
       });
-      artifacts.push({ kind: "boilerplate", path: dir, identity: id, valid: true });
+      artifacts.push({ kind: "boilerplate", path: dir, identity: id, valid });
     } catch (error) {
       diagnostics.push({
         code: "INVALID_BOILERPLATE_MANIFEST",
@@ -217,12 +317,152 @@ export async function loadCatalogSnapshot(
     }
   }
 
+  const duplicateIds = new Set<CatalogArtifactIdentity>();
+  const firstArtifactById = new Map<CatalogArtifactIdentity, CatalogArtifactRecord>();
+  for (const artifact of artifacts) {
+    if (!artifact.identity) continue;
+    const previous = firstArtifactById.get(artifact.identity);
+    if (!previous) {
+      firstArtifactById.set(artifact.identity, artifact);
+      continue;
+    }
+    previous.valid = false;
+    artifact.valid = false;
+    duplicateIds.add(artifact.identity);
+    diagnostics.push({
+      code: "DUPLICATE_ARTIFACT_IDENTITY",
+      severity: "error",
+      kind: artifact.kind,
+      path: artifact.path,
+      identity: artifact.identity,
+      message: `Duplicate catalog artifact identity: ${artifact.identity}`,
+    });
+  }
+
+  const skillsById = new Map(skills.map((skill) => [skill.id, skill]));
+  const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
+  const invalidBoilerplates = new Set<CatalogArtifactIdentity>(duplicateIds);
+  const invalidSkills = new Set<CatalogArtifactIdentity>(duplicateIds);
+
+  for (const boilerplate of discoveredBoilerplates) {
+    const { manifest } = boilerplate;
+    const resolvedSkills: CatalogSkill[] = [];
+    const declaredLocalIds = new Set<CatalogArtifactIdentity>();
+    const seenDeclarations = new Set<string>();
+    const seenInstallNames = new Map<string, CatalogArtifactIdentity>();
+
+    for (const ref of manifest.skills) {
+      const id: CatalogArtifactIdentity =
+        ref.source === "shared"
+          ? `shared:${ref.name}`
+          : `boilerplate:${manifest.name}/skills/${ref.name}`;
+      const declarationKey = `${ref.source}:${ref.name}`;
+      if (seenDeclarations.has(declarationKey)) {
+        invalidBoilerplates.add(boilerplate.id);
+        diagnostics.push({
+          code: "DUPLICATE_SKILL_DECLARATION",
+          severity: "error",
+          kind: "boilerplate",
+          path: boilerplate.dir,
+          identity: boilerplate.id,
+          message: `Duplicate skill declaration: ${declarationKey}`,
+        });
+      }
+      seenDeclarations.add(declarationKey);
+
+      const previous = seenInstallNames.get(ref.name);
+      if (previous && previous !== id) {
+        invalidBoilerplates.add(boilerplate.id);
+        diagnostics.push({
+          code: "SKILL_INSTALL_NAME_COLLISION",
+          severity: "error",
+          kind: "boilerplate",
+          path: boilerplate.dir,
+          identity: boilerplate.id,
+          message: `Skill install name ${ref.name} resolves to both ${previous} and ${id}`,
+        });
+      }
+      seenInstallNames.set(ref.name, id);
+      if (ref.source === "local") declaredLocalIds.add(id);
+
+      const skill = skillsById.get(id);
+      if (!skill) {
+        invalidBoilerplates.add(boilerplate.id);
+        diagnostics.push({
+          code: "MISSING_DECLARED_SKILL",
+          severity: "error",
+          kind: "boilerplate",
+          path: boilerplate.dir,
+          identity: boilerplate.id,
+          message: `Declared skill not found: ${id}`,
+        });
+      } else {
+        resolvedSkills.push(skill);
+      }
+    }
+
+    for (const localSkill of skills.filter(
+      (skill) => skill.scope === "local" && skill.boilerplateName === manifest.name,
+    )) {
+      if (!declaredLocalIds.has(localSkill.id)) {
+        invalidBoilerplates.add(boilerplate.id);
+        invalidSkills.add(localSkill.id);
+        diagnostics.push({
+          code: "UNDECLARED_LOCAL_SKILL",
+          severity: "error",
+          kind: "skill",
+          path: localSkill.dir,
+          identity: localSkill.id,
+          message: `Local skill is not declared by boilerplate ${manifest.name}`,
+        });
+      }
+    }
+
+    let workflow: CatalogWorkflow | undefined;
+    if (manifest.workflow) {
+      const workflowId: CatalogArtifactIdentity =
+        manifest.workflow.source === "shared"
+          ? `shared:workflows/${manifest.workflow.name}`
+          : `boilerplate:${manifest.name}/workflow/${manifest.workflow.name}`;
+      workflow = workflowsById.get(workflowId);
+      if (!workflow) {
+        invalidBoilerplates.add(boilerplate.id);
+        diagnostics.push({
+          code: "MISSING_DECLARED_WORKFLOW",
+          severity: "error",
+          kind: "boilerplate",
+          path: boilerplate.dir,
+          identity: boilerplate.id,
+          message: `Declared workflow not found: ${workflowId}`,
+        });
+      }
+    }
+    boilerplate.skills = resolvedSkills;
+    boilerplate.workflow = workflow;
+  }
+
+  for (const artifact of artifacts) {
+    if (
+      artifact.identity &&
+      (invalidBoilerplates.has(artifact.identity) || invalidSkills.has(artifact.identity))
+    ) {
+      artifact.valid = false;
+    }
+  }
+
+  const boilerplates = discoveredBoilerplates.filter(
+    (boilerplate) =>
+      !invalidBoilerplates.has(boilerplate.id) &&
+      artifacts.some((artifact) => artifact.identity === boilerplate.id && artifact.valid),
+  );
+  const validSkills = skills.filter((skill) => !invalidSkills.has(skill.id));
+
   diagnostics.sort((a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code));
   return freezeSnapshot({
     roots,
     artifacts,
     boilerplates,
-    skills,
+    skills: validSkills,
     workflows,
     diagnostics,
     valid: diagnostics.every((diagnostic) => diagnostic.severity !== "error"),

--- a/src/catalog-snapshot.ts
+++ b/src/catalog-snapshot.ts
@@ -19,6 +19,22 @@ export interface CatalogRoots {
   sharedWorkflowsDir: string;
 }
 
+export interface CatalogRootOptions {
+  catalogRoots?: Partial<CatalogRoots>;
+  boilerplatesDir?: string;
+  sharedSkillsDir?: string;
+  sharedWorkflowsDir?: string;
+}
+
+export function catalogRootsFromOptions(options: CatalogRootOptions): Partial<CatalogRoots> {
+  return {
+    ...options.catalogRoots,
+    ...(options.boilerplatesDir ? { boilerplatesDir: options.boilerplatesDir } : {}),
+    ...(options.sharedSkillsDir ? { sharedSkillsDir: options.sharedSkillsDir } : {}),
+    ...(options.sharedWorkflowsDir ? { sharedWorkflowsDir: options.sharedWorkflowsDir } : {}),
+  };
+}
+
 export type CatalogArtifactIdentity =
   | `boilerplate:${string}`
   | `shared:${string}`
@@ -56,6 +72,14 @@ export interface CatalogArtifactRecord {
   valid: boolean;
 }
 
+export type DeepReadonly<T> = T extends (...args: never[]) => unknown
+  ? T
+  : T extends readonly (infer Item)[]
+    ? readonly DeepReadonly<Item>[]
+    : T extends object
+      ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+      : T;
+
 export interface CatalogSkill {
   id: CatalogArtifactIdentity;
   name: string;
@@ -69,13 +93,13 @@ export interface CatalogWorkflow {
   name: string;
   scope: "shared" | "local";
   dir: string;
-  manifest: WorkflowManifest;
+  manifest: DeepReadonly<WorkflowManifest>;
   boilerplateName?: string;
 }
 
 export interface CatalogBoilerplate {
   id: CatalogArtifactIdentity;
-  manifest: BoilerplateManifest;
+  manifest: DeepReadonly<BoilerplateManifest>;
   dir: string;
   templateDir: string;
   skillsDir: string;
@@ -103,6 +127,15 @@ export class CatalogValidationError extends Error {
 export function assertValidCatalog(snapshot: CatalogSnapshot): void {
   const errors = snapshot.diagnostics.filter((diagnostic) => diagnostic.severity === "error");
   if (errors.length > 0) throw new CatalogValidationError(errors);
+}
+
+export function formatCatalogError(error: unknown): string[] {
+  if (error instanceof CatalogValidationError) {
+    return error.diagnostics.map(
+      (diagnostic) => `${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`,
+    );
+  }
+  return [error instanceof Error ? error.message : String(error)];
 }
 
 async function directoryNames(
@@ -190,6 +223,14 @@ async function loadWorkflow(
   }
 }
 
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const nested of Object.values(value as Record<string, unknown>)) deepFreeze(nested);
+    if (!Object.isFrozen(value)) Object.freeze(value);
+  }
+  return value;
+}
+
 function freezeSnapshot(snapshot: CatalogSnapshot): CatalogSnapshot {
   for (const item of snapshot.artifacts) Object.freeze(item);
   for (const item of snapshot.skills) Object.freeze(item);
@@ -205,7 +246,7 @@ function freezeSnapshot(snapshot: CatalogSnapshot): CatalogSnapshot {
   Object.freeze(snapshot.workflows);
   Object.freeze(snapshot.boilerplates);
   Object.freeze(snapshot.diagnostics);
-  return Object.freeze(snapshot);
+  return deepFreeze(snapshot);
 }
 
 export async function loadCatalogSnapshot(
@@ -238,6 +279,8 @@ export async function loadCatalogSnapshot(
 
   for (const directoryName of await directoryNames(roots.boilerplatesDir, diagnostics)) {
     const dir = join(roots.boilerplatesDir, directoryName);
+    const localSkillNames = await directoryNames(join(dir, "skills"), diagnostics, false);
+    const localWorkflowNames = await directoryNames(join(dir, "workflow"), diagnostics, false);
     try {
       const raw = await readFile(join(dir, "boilerplate.json"), "utf8");
       const manifest = boilerplateManifestSchema.parse(JSON.parse(raw));
@@ -270,7 +313,7 @@ export async function loadCatalogSnapshot(
         });
       }
 
-      for (const name of await directoryNames(join(dir, "skills"), diagnostics, false)) {
+      for (const name of localSkillNames) {
         const skillDir = join(dir, "skills", name);
         const loaded = await loadSkill(
           skillDir,
@@ -283,7 +326,7 @@ export async function loadCatalogSnapshot(
         artifacts.push(loaded.artifact);
       }
 
-      for (const name of await directoryNames(join(dir, "workflow"), diagnostics, false)) {
+      for (const name of localWorkflowNames) {
         const workflowDir = join(dir, "workflow", name);
         const loaded = await loadWorkflow(
           workflowDir,
@@ -306,6 +349,28 @@ export async function loadCatalogSnapshot(
       });
       artifacts.push({ kind: "boilerplate", path: dir, identity: id, valid });
     } catch (error) {
+      for (const name of localSkillNames) {
+        const loaded = await loadSkill(
+          join(dir, "skills", name),
+          `boilerplate:${directoryName}/skills/${name}`,
+          "local",
+          diagnostics,
+          directoryName,
+        );
+        loaded.artifact.valid = false;
+        artifacts.push(loaded.artifact);
+      }
+      for (const name of localWorkflowNames) {
+        const loaded = await loadWorkflow(
+          join(dir, "workflow", name),
+          `boilerplate:${directoryName}/workflow/${name}`,
+          "local",
+          diagnostics,
+          directoryName,
+        );
+        loaded.artifact.valid = false;
+        artifacts.push(loaded.artifact);
+      }
       diagnostics.push({
         code: "INVALID_BOILERPLATE_MANIFEST",
         severity: "error",
@@ -343,6 +408,7 @@ export async function loadCatalogSnapshot(
   const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
   const invalidBoilerplates = new Set<CatalogArtifactIdentity>(duplicateIds);
   const invalidSkills = new Set<CatalogArtifactIdentity>(duplicateIds);
+  const invalidWorkflows = new Set<CatalogArtifactIdentity>(duplicateIds);
 
   for (const boilerplate of discoveredBoilerplates) {
     const { manifest } = boilerplate;
@@ -424,7 +490,7 @@ export async function loadCatalogSnapshot(
         manifest.workflow.source === "shared"
           ? `shared:workflows/${manifest.workflow.name}`
           : `boilerplate:${manifest.name}/workflow/${manifest.workflow.name}`;
-      workflow = workflowsById.get(workflowId);
+      workflow = duplicateIds.has(workflowId) ? undefined : workflowsById.get(workflowId);
       if (!workflow) {
         invalidBoilerplates.add(boilerplate.id);
         diagnostics.push({
@@ -444,7 +510,9 @@ export async function loadCatalogSnapshot(
   for (const artifact of artifacts) {
     if (
       artifact.identity &&
-      (invalidBoilerplates.has(artifact.identity) || invalidSkills.has(artifact.identity))
+      (invalidBoilerplates.has(artifact.identity) ||
+        invalidSkills.has(artifact.identity) ||
+        invalidWorkflows.has(artifact.identity))
     ) {
       artifact.valid = false;
     }
@@ -456,14 +524,16 @@ export async function loadCatalogSnapshot(
       artifacts.some((artifact) => artifact.identity === boilerplate.id && artifact.valid),
   );
   const validSkills = skills.filter((skill) => !invalidSkills.has(skill.id));
+  const validWorkflows = workflows.filter((workflow) => !invalidWorkflows.has(workflow.id));
 
-  diagnostics.sort((a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code));
+  const compare = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
+  diagnostics.sort((a, b) => compare(a.path, b.path) || compare(a.code, b.code));
   return freezeSnapshot({
     roots,
     artifacts,
     boilerplates,
     skills: validSkills,
-    workflows,
+    workflows: validWorkflows,
     diagnostics,
     valid: diagnostics.every((diagnostic) => diagnostic.severity !== "error"),
   });

--- a/src/catalog-snapshot.ts
+++ b/src/catalog-snapshot.ts
@@ -14,9 +14,9 @@ import {
 } from "./paths.js";
 
 export interface CatalogRoots {
-  boilerplatesDir: string;
-  sharedSkillsDir: string;
-  sharedWorkflowsDir: string;
+  readonly boilerplatesDir: string;
+  readonly sharedSkillsDir: string;
+  readonly sharedWorkflowsDir: string;
 }
 
 export interface CatalogRootOptions {
@@ -57,19 +57,19 @@ export type CatalogDiagnosticCode =
   | "MISSING_DECLARED_WORKFLOW";
 
 export interface CatalogDiagnostic {
-  code: CatalogDiagnosticCode;
-  severity: "error" | "warning";
-  kind: "catalog" | "boilerplate" | "skill" | "workflow";
-  path: string;
-  identity?: CatalogArtifactIdentity;
-  message: string;
+  readonly code: CatalogDiagnosticCode;
+  readonly severity: "error" | "warning";
+  readonly kind: "catalog" | "boilerplate" | "skill" | "workflow";
+  readonly path: string;
+  readonly identity?: CatalogArtifactIdentity;
+  readonly message: string;
 }
 
 export interface CatalogArtifactRecord {
-  kind: "boilerplate" | "skill" | "workflow";
-  path: string;
-  identity?: CatalogArtifactIdentity;
-  valid: boolean;
+  readonly kind: "boilerplate" | "skill" | "workflow";
+  readonly path: string;
+  readonly identity?: CatalogArtifactIdentity;
+  readonly valid: boolean;
 }
 
 export type DeepReadonly<T> = T extends (...args: never[]) => unknown
@@ -81,40 +81,46 @@ export type DeepReadonly<T> = T extends (...args: never[]) => unknown
       : T;
 
 export interface CatalogSkill {
-  id: CatalogArtifactIdentity;
-  name: string;
-  scope: "shared" | "local";
-  dir: string;
-  boilerplateName?: string;
+  readonly id: CatalogArtifactIdentity;
+  readonly name: string;
+  readonly scope: "shared" | "local";
+  readonly dir: string;
+  readonly boilerplateName?: string;
 }
 
 export interface CatalogWorkflow {
-  id: CatalogArtifactIdentity;
-  name: string;
-  scope: "shared" | "local";
-  dir: string;
-  manifest: DeepReadonly<WorkflowManifest>;
-  boilerplateName?: string;
+  readonly id: CatalogArtifactIdentity;
+  readonly name: string;
+  readonly scope: "shared" | "local";
+  readonly dir: string;
+  readonly manifest: DeepReadonly<WorkflowManifest>;
+  readonly boilerplateName?: string;
 }
 
 export interface CatalogBoilerplate {
-  id: CatalogArtifactIdentity;
-  manifest: DeepReadonly<BoilerplateManifest>;
-  dir: string;
-  templateDir: string;
-  skillsDir: string;
-  skills: CatalogSkill[];
-  workflow?: CatalogWorkflow;
+  readonly id: CatalogArtifactIdentity;
+  readonly manifest: DeepReadonly<BoilerplateManifest>;
+  readonly dir: string;
+  readonly templateDir: string;
+  readonly skillsDir: string;
+  readonly skills: readonly CatalogSkill[];
+  readonly workflow?: CatalogWorkflow;
 }
 
+type MutableCatalogArtifactRecord = Omit<CatalogArtifactRecord, "valid"> & { valid: boolean };
+type MutableCatalogBoilerplate = Omit<CatalogBoilerplate, "skills" | "workflow"> & {
+  skills: CatalogSkill[];
+  workflow?: CatalogWorkflow;
+};
+
 export interface CatalogSnapshot {
-  roots: Readonly<CatalogRoots>;
-  artifacts: readonly CatalogArtifactRecord[];
-  boilerplates: readonly CatalogBoilerplate[];
-  skills: readonly CatalogSkill[];
-  workflows: readonly CatalogWorkflow[];
-  diagnostics: readonly CatalogDiagnostic[];
-  valid: boolean;
+  readonly roots: Readonly<CatalogRoots>;
+  readonly artifacts: readonly CatalogArtifactRecord[];
+  readonly boilerplates: readonly CatalogBoilerplate[];
+  readonly skills: readonly CatalogSkill[];
+  readonly workflows: readonly CatalogWorkflow[];
+  readonly diagnostics: readonly CatalogDiagnostic[];
+  readonly valid: boolean;
 }
 
 export class CatalogValidationError extends Error {
@@ -168,7 +174,7 @@ async function loadSkill(
   scope: "shared" | "local",
   diagnostics: CatalogDiagnostic[],
   boilerplateName?: string,
-): Promise<{ skill?: CatalogSkill; artifact: CatalogArtifactRecord }> {
+): Promise<{ skill?: CatalogSkill; artifact: MutableCatalogArtifactRecord }> {
   const name = basename(dir);
   try {
     const content = await readFile(join(dir, "SKILL.md"), "utf8");
@@ -196,7 +202,7 @@ async function loadWorkflow(
   scope: "shared" | "local",
   diagnostics: CatalogDiagnostic[],
   boilerplateName?: string,
-): Promise<{ workflow?: CatalogWorkflow; artifact: CatalogArtifactRecord }> {
+): Promise<{ workflow?: CatalogWorkflow; artifact: MutableCatalogArtifactRecord }> {
   const directoryName = basename(dir);
   try {
     const raw = await readFile(join(dir, "workflow.json"), "utf8");
@@ -258,10 +264,10 @@ export async function loadCatalogSnapshot(
     sharedWorkflowsDir: options.sharedWorkflowsDir ?? defaultSharedWorkflowsDir(),
   };
   const diagnostics: CatalogDiagnostic[] = [];
-  const artifacts: CatalogArtifactRecord[] = [];
+  const artifacts: MutableCatalogArtifactRecord[] = [];
   const skills: CatalogSkill[] = [];
   const workflows: CatalogWorkflow[] = [];
-  const discoveredBoilerplates: CatalogBoilerplate[] = [];
+  const discoveredBoilerplates: MutableCatalogBoilerplate[] = [];
 
   for (const name of await directoryNames(roots.sharedSkillsDir, diagnostics)) {
     const dir = join(roots.sharedSkillsDir, name);
@@ -383,7 +389,7 @@ export async function loadCatalogSnapshot(
   }
 
   const duplicateIds = new Set<CatalogArtifactIdentity>();
-  const firstArtifactById = new Map<CatalogArtifactIdentity, CatalogArtifactRecord>();
+  const firstArtifactById = new Map<CatalogArtifactIdentity, MutableCatalogArtifactRecord>();
   for (const artifact of artifacts) {
     if (!artifact.identity) continue;
     const previous = firstArtifactById.get(artifact.identity);

--- a/src/catalog-snapshot.ts
+++ b/src/catalog-snapshot.ts
@@ -1,0 +1,230 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  boilerplateManifestSchema,
+  type BoilerplateManifest,
+  type WorkflowManifest,
+} from "./schema.js";
+import { assertSkillCompliant } from "./skill-frontmatter.js";
+import {
+  defaultBoilerplatesDir,
+  defaultSharedSkillsDir,
+  defaultSharedWorkflowsDir,
+} from "./paths.js";
+
+export interface CatalogRoots {
+  boilerplatesDir: string;
+  sharedSkillsDir: string;
+  sharedWorkflowsDir: string;
+}
+
+export type CatalogArtifactIdentity =
+  | `boilerplate:${string}`
+  | `shared:${string}`
+  | `boilerplate:${string}/skills/${string}`
+  | `shared:workflows/${string}`
+  | `boilerplate:${string}/workflow/${string}`;
+
+export type CatalogDiagnosticCode =
+  | "CATALOG_ROOT_UNREADABLE"
+  | "INVALID_BOILERPLATE_MANIFEST"
+  | "BOILERPLATE_NAME_MISMATCH"
+  | "DUPLICATE_ARTIFACT_IDENTITY"
+  | "MISSING_TEMPLATE"
+  | "INVALID_SKILL_METADATA"
+  | "MISSING_DECLARED_SKILL"
+  | "UNDECLARED_LOCAL_SKILL"
+  | "DUPLICATE_SKILL_DECLARATION"
+  | "SKILL_INSTALL_NAME_COLLISION"
+  | "INVALID_WORKFLOW_METADATA"
+  | "MISSING_DECLARED_WORKFLOW";
+
+export interface CatalogDiagnostic {
+  code: CatalogDiagnosticCode;
+  severity: "error" | "warning";
+  kind: "catalog" | "boilerplate" | "skill" | "workflow";
+  path: string;
+  identity?: CatalogArtifactIdentity;
+  message: string;
+}
+
+export interface CatalogArtifactRecord {
+  kind: "boilerplate" | "skill" | "workflow";
+  path: string;
+  identity?: CatalogArtifactIdentity;
+  valid: boolean;
+}
+
+export interface CatalogSkill {
+  id: CatalogArtifactIdentity;
+  name: string;
+  scope: "shared" | "local";
+  dir: string;
+  boilerplateName?: string;
+}
+
+export interface CatalogWorkflow {
+  id: CatalogArtifactIdentity;
+  name: string;
+  scope: "shared" | "local";
+  dir: string;
+  manifest: WorkflowManifest;
+  boilerplateName?: string;
+}
+
+export interface CatalogBoilerplate {
+  id: CatalogArtifactIdentity;
+  manifest: BoilerplateManifest;
+  dir: string;
+  templateDir: string;
+  skillsDir: string;
+  skills: CatalogSkill[];
+  workflow?: CatalogWorkflow;
+}
+
+export interface CatalogSnapshot {
+  roots: Readonly<CatalogRoots>;
+  artifacts: readonly CatalogArtifactRecord[];
+  boilerplates: readonly CatalogBoilerplate[];
+  skills: readonly CatalogSkill[];
+  workflows: readonly CatalogWorkflow[];
+  diagnostics: readonly CatalogDiagnostic[];
+  valid: boolean;
+}
+
+export class CatalogValidationError extends Error {
+  constructor(readonly diagnostics: readonly CatalogDiagnostic[]) {
+    super(`Catalog validation failed with ${diagnostics.length} error(s)`);
+    this.name = "CatalogValidationError";
+  }
+}
+
+export function assertValidCatalog(snapshot: CatalogSnapshot): void {
+  const errors = snapshot.diagnostics.filter((diagnostic) => diagnostic.severity === "error");
+  if (errors.length > 0) throw new CatalogValidationError(errors);
+}
+
+async function directoryNames(root: string, diagnostics: CatalogDiagnostic[]): Promise<string[]> {
+  try {
+    const entries = await readdir(root, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+  } catch (error) {
+    diagnostics.push({
+      code: "CATALOG_ROOT_UNREADABLE",
+      severity: "error",
+      kind: "catalog",
+      path: root,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+function freezeSnapshot(snapshot: CatalogSnapshot): CatalogSnapshot {
+  for (const item of snapshot.artifacts) Object.freeze(item);
+  for (const item of snapshot.skills) Object.freeze(item);
+  for (const item of snapshot.workflows) Object.freeze(item);
+  for (const item of snapshot.boilerplates) {
+    Object.freeze(item.skills);
+    Object.freeze(item);
+  }
+  for (const item of snapshot.diagnostics) Object.freeze(item);
+  Object.freeze(snapshot.roots);
+  Object.freeze(snapshot.artifacts);
+  Object.freeze(snapshot.skills);
+  Object.freeze(snapshot.workflows);
+  Object.freeze(snapshot.boilerplates);
+  Object.freeze(snapshot.diagnostics);
+  return Object.freeze(snapshot);
+}
+
+export async function loadCatalogSnapshot(
+  options: Partial<CatalogRoots> = {},
+): Promise<CatalogSnapshot> {
+  const roots: CatalogRoots = {
+    boilerplatesDir: options.boilerplatesDir ?? defaultBoilerplatesDir(),
+    sharedSkillsDir: options.sharedSkillsDir ?? defaultSharedSkillsDir(),
+    sharedWorkflowsDir: options.sharedWorkflowsDir ?? defaultSharedWorkflowsDir(),
+  };
+  const diagnostics: CatalogDiagnostic[] = [];
+  const artifacts: CatalogArtifactRecord[] = [];
+  const skills: CatalogSkill[] = [];
+  const workflows: CatalogWorkflow[] = [];
+  const boilerplates: CatalogBoilerplate[] = [];
+
+  const sharedSkillNames = await directoryNames(roots.sharedSkillsDir, diagnostics);
+  for (const name of sharedSkillNames) {
+    const dir = join(roots.sharedSkillsDir, name);
+    const id = `shared:${name}` as const;
+    try {
+      const content = await readFile(join(dir, "SKILL.md"), "utf8");
+      assertSkillCompliant(content, { directoryName: name, requireEnrichment: true });
+      skills.push({ id, name, scope: "shared", dir });
+      artifacts.push({ kind: "skill", path: dir, identity: id, valid: true });
+    } catch (error) {
+      diagnostics.push({
+        code: "INVALID_SKILL_METADATA",
+        severity: "error",
+        kind: "skill",
+        path: dir,
+        identity: id,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      artifacts.push({ kind: "skill", path: dir, identity: id, valid: false });
+    }
+  }
+
+  await directoryNames(roots.sharedWorkflowsDir, diagnostics);
+  const boilerplateDirectories = await directoryNames(roots.boilerplatesDir, diagnostics);
+  for (const directoryName of boilerplateDirectories) {
+    const dir = join(roots.boilerplatesDir, directoryName);
+    try {
+      const raw = await readFile(join(dir, "boilerplate.json"), "utf8");
+      const manifest = boilerplateManifestSchema.parse(JSON.parse(raw));
+      const id = `boilerplate:${manifest.name}` as const;
+      const resolvedSkills = manifest.skills
+        .map((ref) =>
+          skills.find(
+            (skill) =>
+              skill.id ===
+              (ref.source === "shared"
+                ? `shared:${ref.name}`
+                : `boilerplate:${manifest.name}/skills/${ref.name}`),
+          ),
+        )
+        .filter((skill): skill is CatalogSkill => Boolean(skill));
+      boilerplates.push({
+        id,
+        manifest,
+        dir,
+        templateDir: join(dir, "template"),
+        skillsDir: join(dir, "skills"),
+        skills: resolvedSkills,
+      });
+      artifacts.push({ kind: "boilerplate", path: dir, identity: id, valid: true });
+    } catch (error) {
+      diagnostics.push({
+        code: "INVALID_BOILERPLATE_MANIFEST",
+        severity: "error",
+        kind: "boilerplate",
+        path: dir,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      artifacts.push({ kind: "boilerplate", path: dir, valid: false });
+    }
+  }
+
+  diagnostics.sort((a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code));
+  return freezeSnapshot({
+    roots,
+    artifacts,
+    boilerplates,
+    skills,
+    workflows,
+    diagnostics,
+    valid: diagnostics.every((diagnostic) => diagnostic.severity !== "error"),
+  });
+}

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1,68 +1,30 @@
-import { readdir, readFile, stat } from "node:fs/promises";
-import { join } from "node:path";
-import { boilerplateManifestSchema, type BoilerplateManifest } from "./schema.js";
 import { defaultBoilerplatesDir } from "./paths.js";
+import {
+  assertValidCatalog,
+  loadCatalogSnapshot,
+  type CatalogBoilerplate,
+} from "./catalog-snapshot.js";
 
-export interface Boilerplate {
-  manifest: BoilerplateManifest;
-  /** Absolute path to the boilerplate directory in the catalog. */
-  dir: string;
-  /** Absolute path to the files copied into a new project. */
-  templateDir: string;
-  /** Absolute path to the bundled skills directory. */
-  skillsDir: string;
-}
-
-async function isDirectory(path: string): Promise<boolean> {
-  try {
-    return (await stat(path)).isDirectory();
-  } catch {
-    return false;
-  }
-}
-
-async function loadBoilerplate(dir: string): Promise<Boilerplate> {
-  const manifestPath = join(dir, "boilerplate.json");
-  const raw = await readFile(manifestPath, "utf8");
-  const manifest = boilerplateManifestSchema.parse(JSON.parse(raw));
-  return {
-    manifest,
-    dir,
-    templateDir: join(dir, "template"),
-    skillsDir: join(dir, "skills"),
-  };
-}
+export type Boilerplate = CatalogBoilerplate;
 
 export async function listBoilerplates(
   boilerplatesDir = defaultBoilerplatesDir(),
 ): Promise<Boilerplate[]> {
-  let entries: string[];
-  try {
-    entries = await readdir(boilerplatesDir);
-  } catch {
-    return [];
-  }
-  const found: Boilerplate[] = [];
-  for (const entry of entries.sort()) {
-    const dir = join(boilerplatesDir, entry);
-    if (!(await isDirectory(dir))) continue;
-    try {
-      found.push(await loadBoilerplate(dir));
-    } catch {
-      // Skip directories without a valid boilerplate.json.
-    }
-  }
-  return found;
+  const snapshot = await loadCatalogSnapshot({ boilerplatesDir });
+  assertValidCatalog(snapshot);
+  return [...snapshot.boilerplates];
 }
 
 export async function getBoilerplate(
   name: string,
   boilerplatesDir = defaultBoilerplatesDir(),
 ): Promise<Boilerplate> {
-  const all = await listBoilerplates(boilerplatesDir);
-  const match = all.find((b) => b.manifest.name === name);
+  const snapshot = await loadCatalogSnapshot({ boilerplatesDir });
+  assertValidCatalog(snapshot);
+  const match = snapshot.boilerplates.find((boilerplate) => boilerplate.manifest.name === name);
   if (!match) {
-    const available = all.map((b) => b.manifest.name).join(", ") || "(none)";
+    const available =
+      snapshot.boilerplates.map((boilerplate) => boilerplate.manifest.name).join(", ") || "(none)";
     throw new Error(`Unknown boilerplate: "${name}". Available: ${available}.`);
   }
   return match;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { resolve } from "node:path";
-import { loadCatalogSnapshot } from "./catalog-snapshot.js";
+import { assertValidCatalog, formatCatalogError, loadCatalogSnapshot } from "./catalog-snapshot.js";
 import { runListBoilerplates } from "./list-boilerplates-command.js";
 import { scaffold } from "./scaffold.js";
 import { parseAgents, type AgentId } from "./agents.js";
@@ -10,7 +10,7 @@ import { promoteSkill, parsePromoteTarget } from "./promote.js";
 import { syncSkills } from "./sync-skills.js";
 import { syncUpstreamSkills } from "./upstream-sync.js";
 import { buildRegistryFromCatalog, saveRegistry } from "./registry.js";
-import { defaultRegistryPath, defaultSharedWorkflowsDir } from "./paths.js";
+import { defaultRegistryPath } from "./paths.js";
 import { getBoilerplate } from "./catalog.js";
 import {
   GitHubSkillSource,
@@ -26,6 +26,10 @@ import { exportPlugin } from "./export-plugin.js";
 import { DEFAULT_PLUGIN_DIRNAME } from "./plugin.js";
 
 const program = new Command();
+
+function reportError(error: unknown): void {
+  for (const line of formatCatalogError(error)) console.error(line);
+}
 
 program
   .name("bwai-cli")
@@ -116,31 +120,16 @@ program
   .command("list-workflows")
   .description("List GetSuperpower workflow bundles shipped with bwai-cli.")
   .action(async () => {
-    const { readdir, readFile } = await import("node:fs/promises");
-    const { join } = await import("node:path");
-    const workflowsDir = defaultSharedWorkflowsDir();
-    let entries: import("node:fs").Dirent[];
-    try {
-      entries = await readdir(workflowsDir, { withFileTypes: true });
-    } catch {
+    const snapshot = await loadCatalogSnapshot();
+    assertValidCatalog(snapshot);
+    const workflows = snapshot.workflows.filter((workflow) => workflow.scope === "shared");
+    if (workflows.length === 0) {
       console.log("No workflows found.");
       return;
     }
-    const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
-    if (dirs.length === 0) {
-      console.log("No workflows found.");
-      return;
-    }
-    for (const name of dirs) {
-      const workflowJson = join(workflowsDir, name, "workflow.json");
-      try {
-        const raw = await readFile(workflowJson, "utf8");
-        const parsed = JSON.parse(raw) as { description?: string; version?: string };
-        console.log(`${name}  (v${parsed.version ?? "?"})`);
-        if (parsed.description) console.log(`  ${parsed.description}`);
-      } catch {
-        console.log(`${name}  (invalid or missing workflow.json)`);
-      }
+    for (const workflow of workflows) {
+      console.log(`${workflow.name}  (v${workflow.manifest.version})`);
+      console.log(`  ${workflow.manifest.description}`);
     }
   });
 
@@ -189,7 +178,7 @@ program
         console.log(`Copilot settings: ${result.copilotSettingsPath}`);
       }
     } catch (error) {
-      console.error(error instanceof Error ? error.message : error);
+      reportError(error);
       process.exitCode = 1;
     }
   });
@@ -262,7 +251,7 @@ program
           console.log("Then run: $bwai-advisor  <your idea or @path/to/brief.md>");
         }
       } catch (error) {
-        console.error(error instanceof Error ? error.message : error);
+        reportError(error);
         process.exitCode = 1;
       }
     },
@@ -287,7 +276,7 @@ program
       console.log(`Passed: ${result.passed ? "yes" : "no"}`);
       if (!result.passed) process.exitCode = 1;
     } catch (error) {
-      console.error(error instanceof Error ? error.message : error);
+      reportError(error);
       process.exitCode = 1;
     }
   });
@@ -486,7 +475,7 @@ program
         console.log(`SHA-256: ${result.sha256}`);
         console.log(`Registry: ${result.registryPath}`);
       } catch (error) {
-        console.error(error instanceof Error ? error.message : error);
+        reportError(error);
         process.exitCode = 1;
       }
     },
@@ -512,7 +501,7 @@ program
         `Registry refreshed: ${result.registryPath} (${result.registrySkillCount} skills)`,
       );
     } catch (error) {
-      console.error(error instanceof Error ? error.message : error);
+      reportError(error);
       process.exitCode = 1;
     }
   });
@@ -560,7 +549,7 @@ program
         }
         if (result.entries.some((e) => e.status === "failed")) process.exitCode = 1;
       } catch (error) {
-        console.error(error instanceof Error ? error.message : error);
+        reportError(error);
         process.exitCode = 1;
       }
     },
@@ -575,13 +564,12 @@ program
       await saveRegistry(index, defaultRegistryPath());
       console.log(`Registry refreshed: ${defaultRegistryPath()} (${index.skills.length} skills)`);
     } catch (error) {
-      console.error(error instanceof Error ? error.message : error);
+      reportError(error);
       process.exitCode = 1;
     }
   });
 
 program.parseAsync(process.argv).catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`Error: ${message}`);
+  reportError(error);
   process.exitCode = 1;
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { stat } from "node:fs/promises";
 import { resolve } from "node:path";
 import { assertValidCatalog, formatCatalogError, loadCatalogSnapshot } from "./catalog-snapshot.js";
 import { runListBoilerplates } from "./list-boilerplates-command.js";
@@ -152,12 +153,16 @@ program
     try {
       let outDir = out;
       if (!outDir) {
-        const { listBoilerplates } = await import("./catalog.js");
-        const names = (await listBoilerplates()).map((b) => b.manifest.name);
-        if (names.includes(source)) {
-          outDir = resolve(process.cwd(), `bwai.${source}`);
-        } else {
+        const projectDir = resolve(process.cwd(), source);
+        try {
+          await stat(projectDir);
           outDir = resolve(process.cwd(), source, DEFAULT_PLUGIN_DIRNAME);
+        } catch {
+          const { listBoilerplates } = await import("./catalog.js");
+          const names = (await listBoilerplates()).map((b) => b.manifest.name);
+          outDir = names.includes(source)
+            ? resolve(process.cwd(), `bwai.${source}`)
+            : resolve(process.cwd(), source, DEFAULT_PLUGIN_DIRNAME);
         }
       } else {
         outDir = resolve(process.cwd(), outDir);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { resolve } from "node:path";
-import { listBoilerplates } from "./catalog.js";
+import { loadCatalogSnapshot } from "./catalog-snapshot.js";
+import { runListBoilerplates } from "./list-boilerplates-command.js";
 import { scaffold } from "./scaffold.js";
 import { parseAgents, type AgentId } from "./agents.js";
 import { scanCatalog } from "./catalog-scan.js";
@@ -39,20 +40,12 @@ program
   .alias("list")
   .description("List available boilerplates in the catalog.")
   .action(async () => {
-    const boilerplates = await listBoilerplates();
-    if (boilerplates.length === 0) {
-      console.log("No boilerplates found.");
-      return;
-    }
-    for (const b of boilerplates) {
-      console.log(`${b.manifest.name}  (${b.manifest.stack})`);
-      console.log(`  ${b.manifest.description}`);
-      console.log(`  skills: ${b.manifest.skills.map((s) => s.name).join(", ") || "(none)"}`);
-      if (b.manifest.workflow) {
-        console.log(`  workflow: ${b.manifest.workflow.source}:${b.manifest.workflow.name}`);
-      }
-      console.log(`  default agents: ${b.manifest.defaultAgents.join(", ")}`);
-    }
+    const exitCode = await runListBoilerplates({
+      loadSnapshot: () => loadCatalogSnapshot(),
+      stdout: (line) => console.log(line),
+      stderr: (line) => console.error(line),
+    });
+    if (exitCode !== 0) process.exitCode = exitCode;
   });
 
 program

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,6 +1,6 @@
 import { access, constants } from "node:fs/promises";
 import { join } from "node:path";
-import { listBoilerplates } from "./catalog.js";
+import { loadCatalogSnapshot, type CatalogRoots } from "./catalog-snapshot.js";
 import { SkillSpectorScanner } from "./scan.js";
 import { readLock } from "./provenance.js";
 import { checkGlobalAdvisorSkills } from "./global-skills-check.js";
@@ -42,7 +42,10 @@ async function commandExists(command: string): Promise<boolean> {
 }
 
 /** Environment and project readiness checks for bwai-cli users. */
-export async function runDoctor(cwd = process.cwd()): Promise<DoctorReport> {
+export async function runDoctor(
+  cwd = process.cwd(),
+  options: { catalogRoots?: Partial<CatalogRoots> } = {},
+): Promise<DoctorReport> {
   const checks: DoctorCheck[] = [];
 
   const major = nodeMajorVersion();
@@ -61,14 +64,19 @@ export async function runDoctor(cwd = process.cwd()): Promise<DoctorReport> {
   }
 
   try {
-    const boilerplates = await listBoilerplates();
+    const snapshot = await loadCatalogSnapshot(options.catalogRoots);
+    const errorCount = snapshot.diagnostics.filter(
+      (diagnostic) => diagnostic.severity === "error",
+    ).length;
     checks.push({
       name: "catalog",
-      status: boilerplates.length > 0 ? "ok" : "fail",
+      status: snapshot.valid && snapshot.boilerplates.length > 0 ? "ok" : "fail",
       message:
-        boilerplates.length > 0
-          ? `${boilerplates.length} boilerplate(s) in catalog`
-          : "No boilerplates found — reinstall bwai-cli or run from repo root",
+        errorCount > 0
+          ? `Catalog invalid: ${errorCount} error(s)`
+          : snapshot.boilerplates.length > 0
+            ? `${snapshot.boilerplates.length} boilerplate(s) in catalog`
+            : "No boilerplates found — reinstall bwai-cli or run from repo root",
     });
   } catch (err) {
     checks.push({

--- a/src/export-plugin.ts
+++ b/src/export-plugin.ts
@@ -2,6 +2,7 @@ import { mkdir, readdir, readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import {
   assertValidCatalog,
+  catalogRootsFromOptions,
   loadCatalogSnapshot,
   type CatalogBoilerplate,
   type CatalogRoots,
@@ -161,10 +162,12 @@ async function exportFromProject(
 export async function exportPlugin(options: ExportPluginOptions): Promise<ExportPluginResult> {
   const outDir = resolve(options.outDir);
   const source = options.source;
-  const snapshot = await loadCatalogSnapshot({
-    ...options.catalogRoots,
-    ...(options.boilerplatesDir ? { boilerplatesDir: options.boilerplatesDir } : {}),
-  });
+  const projectDir = resolve(source);
+  if (await pathExists(projectDir)) {
+    await mkdir(outDir, { recursive: true });
+    return exportFromProject(projectDir, outDir, Boolean(options.writeCopilotSettings));
+  }
+  const snapshot = await loadCatalogSnapshot(catalogRootsFromOptions(options));
   assertValidCatalog(snapshot);
   const boilerplate = snapshot.boilerplates.find((entry) => entry.manifest.name === source);
   if (boilerplate) {
@@ -172,13 +175,5 @@ export async function exportPlugin(options: ExportPluginOptions): Promise<Export
     return exportFromBoilerplate(boilerplate, outDir);
   }
 
-  const projectDir = resolve(source);
-  if (!(await pathExists(projectDir))) {
-    throw new Error(
-      `Unknown source "${source}" — not a catalog boilerplate and path does not exist`,
-    );
-  }
-
-  await mkdir(outDir, { recursive: true });
-  return exportFromProject(projectDir, outDir, Boolean(options.writeCopilotSettings));
+  throw new Error(`Unknown source "${source}" — not a catalog boilerplate and path does not exist`);
 }

--- a/src/export-plugin.ts
+++ b/src/export-plugin.ts
@@ -1,9 +1,11 @@
 import { mkdir, readdir, readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
-import { getBoilerplate, listBoilerplates } from "./catalog.js";
-import { defaultSharedSkillsDir } from "./paths.js";
-import { assertSkillExists, resolveSkillDirectory } from "./skills.js";
-import { resolveWorkflowDirectory } from "./workflows.js";
+import {
+  assertValidCatalog,
+  loadCatalogSnapshot,
+  type CatalogBoilerplate,
+  type CatalogRoots,
+} from "./catalog-snapshot.js";
 import {
   defaultPluginDir,
   listSkillSources,
@@ -24,6 +26,7 @@ export interface ExportPluginOptions {
   /** When exporting a project into itself, also write Copilot settings. */
   writeCopilotSettings?: boolean;
   boilerplatesDir?: string;
+  catalogRoots?: Partial<CatalogRoots>;
 }
 
 export interface ExportPluginResult extends WriteAgentPluginResult {
@@ -41,41 +44,15 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
-async function isBoilerplateName(name: string, boilerplatesDir?: string): Promise<boolean> {
-  try {
-    const all = await listBoilerplates(boilerplatesDir);
-    return all.some((b) => b.manifest.name === name);
-  } catch {
-    return false;
-  }
-}
-
 async function exportFromBoilerplate(
-  boilerplateName: string,
+  boilerplate: CatalogBoilerplate,
   outDir: string,
-  boilerplatesDir?: string,
 ): Promise<ExportPluginResult> {
-  const boilerplate = await getBoilerplate(boilerplateName, boilerplatesDir);
-  const catalogPaths = {
-    boilerplateName: boilerplate.manifest.name,
-    boilerplateSkillsDir: boilerplate.skillsDir,
-    sharedSkillsDir: defaultSharedSkillsDir(),
-  };
-
-  const skills = [];
-  for (const skill of boilerplate.manifest.skills) {
-    const dir = resolveSkillDirectory(skill, catalogPaths);
-    await assertSkillExists(dir, skill.name);
-    skills.push({ name: skill.name, dir });
-  }
+  const skills = boilerplate.skills.map((skill) => ({ name: skill.name, dir: skill.dir }));
 
   // Include delivery workflow skills when the boilerplate declares a workflow (P1-5).
-  if (boilerplate.manifest.workflow) {
-    const workflowDir = resolveWorkflowDirectory(boilerplate.manifest.workflow, {
-      boilerplateName: boilerplate.manifest.name,
-      boilerplateDir: boilerplate.dir,
-    });
-    const wfSkills = await listSkillSources(join(workflowDir, "skills"));
+  if (boilerplate.workflow) {
+    const wfSkills = await listSkillSources(join(boilerplate.workflow.dir, "skills"));
     for (const s of wfSkills) {
       if (!skills.some((x) => x.name === s.name)) skills.push(s);
     }
@@ -183,11 +160,16 @@ async function exportFromProject(
  */
 export async function exportPlugin(options: ExportPluginOptions): Promise<ExportPluginResult> {
   const outDir = resolve(options.outDir);
-  await mkdir(outDir, { recursive: true });
-
   const source = options.source;
-  if (await isBoilerplateName(source, options.boilerplatesDir)) {
-    return exportFromBoilerplate(source, outDir, options.boilerplatesDir);
+  const snapshot = await loadCatalogSnapshot({
+    ...options.catalogRoots,
+    ...(options.boilerplatesDir ? { boilerplatesDir: options.boilerplatesDir } : {}),
+  });
+  assertValidCatalog(snapshot);
+  const boilerplate = snapshot.boilerplates.find((entry) => entry.manifest.name === source);
+  if (boilerplate) {
+    await mkdir(outDir, { recursive: true });
+    return exportFromBoilerplate(boilerplate, outDir);
   }
 
   const projectDir = resolve(source);
@@ -197,5 +179,6 @@ export async function exportPlugin(options: ExportPluginOptions): Promise<Export
     );
   }
 
+  await mkdir(outDir, { recursive: true });
   return exportFromProject(projectDir, outDir, Boolean(options.writeCopilotSettings));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,21 @@
 export { listBoilerplates, getBoilerplate } from "./catalog.js";
 export type { Boilerplate } from "./catalog.js";
+export {
+  assertValidCatalog,
+  CatalogValidationError,
+  loadCatalogSnapshot,
+} from "./catalog-snapshot.js";
+export type {
+  CatalogArtifactIdentity,
+  CatalogArtifactRecord,
+  CatalogBoilerplate,
+  CatalogDiagnostic,
+  CatalogDiagnosticCode,
+  CatalogRoots,
+  CatalogSkill,
+  CatalogSnapshot,
+  CatalogWorkflow,
+} from "./catalog-snapshot.js";
 export { scaffold } from "./scaffold.js";
 export type { ScaffoldOptions, ScaffoldResult } from "./scaffold.js";
 export { scanProject, SkillSpectorScanner } from "./scan.js";

--- a/src/install-skill.ts
+++ b/src/install-skill.ts
@@ -1,9 +1,14 @@
-import { cp, mkdir, readdir, stat } from "node:fs/promises";
+import { cp, mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { AgentId } from "./agents.js";
-import { defaultSharedSkillsDir } from "./paths.js";
-import { assertSkillExists } from "./skills.js";
+import {
+  assertValidCatalog,
+  catalogRootsFromOptions,
+  loadCatalogSnapshot,
+  type CatalogRoots,
+  type CatalogSnapshot,
+} from "./catalog-snapshot.js";
 
 /** Global install roots (under the user's home directory). */
 export const GLOBAL_AGENT_TARGETS: Record<AgentId, string> = {
@@ -27,6 +32,7 @@ export interface InstallSkillOptions {
   /** Also install SKILL_DEPENDENCIES for this skill. Default true for CLI. */
   withDeps?: boolean;
   sharedSkillsDir?: string;
+  catalogRoots?: Partial<CatalogRoots>;
 }
 
 export interface InstalledSkillPath {
@@ -39,26 +45,26 @@ export interface InstallSkillResult {
   installed: InstalledSkillPath[];
 }
 
+export interface InstallableSkillOptions {
+  sharedSkillsDir?: string;
+  catalogRoots?: Partial<CatalogRoots>;
+}
+
+async function loadInstallCatalog(options: InstallableSkillOptions = {}): Promise<CatalogSnapshot> {
+  const snapshot = await loadCatalogSnapshot(catalogRootsFromOptions(options));
+  assertValidCatalog(snapshot);
+  return snapshot;
+}
+
 export async function listInstallableSkills(
-  sharedSkillsDir: string = defaultSharedSkillsDir(),
+  options: InstallableSkillOptions | string = {},
 ): Promise<string[]> {
-  let entries: import("node:fs").Dirent[];
-  try {
-    entries = await readdir(sharedSkillsDir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  const names: string[] = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    try {
-      await stat(join(sharedSkillsDir, entry.name, "SKILL.md"));
-      names.push(entry.name);
-    } catch {
-      // skip non-skill dirs
-    }
-  }
-  return names.sort();
+  const normalized = typeof options === "string" ? { sharedSkillsDir: options } : options;
+  const snapshot = await loadInstallCatalog(normalized);
+  return snapshot.skills
+    .filter((skill) => skill.scope === "shared")
+    .map((skill) => skill.name)
+    .sort();
 }
 
 async function copySkillToAgents(
@@ -87,10 +93,11 @@ async function copySkillToAgents(
  * Install a shared catalog skill into the user's global agent skill directories.
  */
 export async function installSkill(opts: InstallSkillOptions): Promise<InstallSkillResult> {
-  const sharedDir = opts.sharedSkillsDir ?? defaultSharedSkillsDir();
   const homeDir = opts.homeDir ?? homedir();
   const withDeps = opts.withDeps ?? true;
-  const available = await listInstallableSkills(sharedDir);
+  const snapshot = await loadInstallCatalog(opts);
+  const sharedSkills = snapshot.skills.filter((skill) => skill.scope === "shared");
+  const available = sharedSkills.map((skill) => skill.name).sort();
 
   if (!available.includes(opts.skillName)) {
     throw new Error(
@@ -107,9 +114,9 @@ export async function installSkill(opts: InstallSkillOptions): Promise<InstallSk
 
   const installed: InstalledSkillPath[] = [];
   for (const name of toInstall) {
-    const sourceDir = join(sharedDir, name);
-    await assertSkillExists(sourceDir, name);
-    installed.push(...(await copySkillToAgents(name, sourceDir, opts.agents, homeDir)));
+    const skill = sharedSkills.find((entry) => entry.name === name);
+    if (!skill) throw new Error(`Missing companion skill in catalog: ${name}`);
+    installed.push(...(await copySkillToAgents(name, skill.dir, opts.agents, homeDir)));
   }
 
   return { installed };

--- a/src/list-boilerplates-command.ts
+++ b/src/list-boilerplates-command.ts
@@ -1,0 +1,29 @@
+import type { CatalogBoilerplate, CatalogSnapshot } from "./catalog-snapshot.js";
+
+export interface ListBoilerplatesIo {
+  loadSnapshot: () => Promise<CatalogSnapshot>;
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+}
+
+function renderBoilerplate(boilerplate: CatalogBoilerplate, write: (line: string) => void): void {
+  write(`${boilerplate.manifest.name}  (${boilerplate.manifest.stack})`);
+  write(`  ${boilerplate.manifest.description}`);
+  write(`  skills: ${boilerplate.skills.map((skill) => skill.name).join(", ") || "(none)"}`);
+  if (boilerplate.manifest.workflow) {
+    write(
+      `  workflow: ${boilerplate.manifest.workflow.source}:${boilerplate.manifest.workflow.name}`,
+    );
+  }
+  write(`  default agents: ${boilerplate.manifest.defaultAgents.join(", ")}`);
+}
+
+export async function runListBoilerplates(io: ListBoilerplatesIo): Promise<0 | 1> {
+  const snapshot = await io.loadSnapshot();
+  if (snapshot.boilerplates.length === 0) io.stdout("No boilerplates found.");
+  for (const boilerplate of snapshot.boilerplates) renderBoilerplate(boilerplate, io.stdout);
+  for (const diagnostic of snapshot.diagnostics) {
+    io.stderr(`${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`);
+  }
+  return snapshot.valid ? 0 : 1;
+}

--- a/src/list-boilerplates-command.ts
+++ b/src/list-boilerplates-command.ts
@@ -1,4 +1,9 @@
-import type { CatalogBoilerplate, CatalogSnapshot } from "./catalog-snapshot.js";
+import {
+  CatalogValidationError,
+  formatCatalogError,
+  type CatalogBoilerplate,
+  type CatalogSnapshot,
+} from "./catalog-snapshot.js";
 
 export interface ListBoilerplatesIo {
   loadSnapshot: () => Promise<CatalogSnapshot>;
@@ -22,8 +27,8 @@ export async function runListBoilerplates(io: ListBoilerplatesIo): Promise<0 | 1
   const snapshot = await io.loadSnapshot();
   if (snapshot.boilerplates.length === 0) io.stdout("No boilerplates found.");
   for (const boilerplate of snapshot.boilerplates) renderBoilerplate(boilerplate, io.stdout);
-  for (const diagnostic of snapshot.diagnostics) {
-    io.stderr(`${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`);
+  for (const line of formatCatalogError(new CatalogValidationError(snapshot.diagnostics))) {
+    io.stderr(line);
   }
   return snapshot.valid ? 0 : 1;
 }

--- a/src/promote.ts
+++ b/src/promote.ts
@@ -1,7 +1,12 @@
 import { cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { spawn } from "node:child_process";
-import { getBoilerplate } from "./catalog.js";
+import {
+  assertValidCatalog,
+  loadCatalogSnapshot,
+  type CatalogBoilerplate,
+  type CatalogRoots,
+} from "./catalog-snapshot.js";
 import {
   buildRegistryFromCatalog,
   loadRegistry,
@@ -9,7 +14,7 @@ import {
   type RegistrySkill,
   type SkillsIndex,
 } from "./registry.js";
-import { defaultBoilerplatesDir, defaultRegistryPath, defaultSharedSkillsDir } from "./paths.js";
+import { defaultRegistryPath } from "./paths.js";
 import { sha256 } from "./provenance.js";
 import { assertCatalogSkill, assertSkillExists } from "./skills.js";
 import { scanSkillDirectory, type SkillScanner } from "./scan.js";
@@ -29,6 +34,8 @@ export interface PromoteOptions {
   registryPath?: string;
   sharedSkillsDir?: string;
   boilerplatesDir?: string;
+  sharedWorkflowsDir?: string;
+  catalogRoots?: Partial<CatalogRoots>;
 }
 
 export interface PromoteResult {
@@ -91,13 +98,12 @@ async function resolveSourceDir(opts: PromoteOptions): Promise<{ dir: string; cl
   throw new Error("Provide --from <path> or --from-url <git-url> for the skill source.");
 }
 
-function resolveTargetDir(opts: PromoteOptions): string {
+function resolveTargetDir(opts: PromoteOptions, roots: CatalogRoots): string {
   const target = opts.target ?? { kind: "shared" };
   if (target.kind === "shared") {
-    return join(opts.sharedSkillsDir ?? defaultSharedSkillsDir(), opts.skillName);
+    return join(roots.sharedSkillsDir, opts.skillName);
   }
-  const boilerplatesDir = opts.boilerplatesDir ?? defaultBoilerplatesDir();
-  return join(boilerplatesDir, target.name, "skills", opts.skillName);
+  return join(roots.boilerplatesDir, target.name, "skills", opts.skillName);
 }
 
 function parsePromoteTarget(raw: string | undefined): PromoteTarget {
@@ -114,9 +120,20 @@ export async function promoteSkill(opts: PromoteOptions): Promise<PromoteResult>
   const threshold = opts.threshold ?? 30;
   const target = opts.target ?? { kind: "shared" };
   const registryPath = opts.registryPath ?? defaultRegistryPath();
+  const snapshot = await loadCatalogSnapshot({
+    ...opts.catalogRoots,
+    ...(opts.boilerplatesDir ? { boilerplatesDir: opts.boilerplatesDir } : {}),
+    ...(opts.sharedSkillsDir ? { sharedSkillsDir: opts.sharedSkillsDir } : {}),
+    ...(opts.sharedWorkflowsDir ? { sharedWorkflowsDir: opts.sharedWorkflowsDir } : {}),
+  });
+  assertValidCatalog(snapshot);
 
+  let targetBoilerplate: CatalogBoilerplate | undefined;
   if (target.kind === "boilerplate") {
-    await getBoilerplate(target.name, opts.boilerplatesDir);
+    targetBoilerplate = snapshot.boilerplates.find(
+      (boilerplate) => boilerplate.manifest.name === target.name,
+    );
+    if (!targetBoilerplate) throw new Error(`Unknown boilerplate: ${target.name}`);
   }
 
   const { dir: sourceDir, cleanup } = await resolveSourceDir(opts);
@@ -147,7 +164,7 @@ export async function promoteSkill(opts: PromoteOptions): Promise<PromoteResult>
       scanStatus = "skipped";
     }
 
-    const targetDir = resolveTargetDir({ ...opts, target });
+    const targetDir = resolveTargetDir({ ...opts, target }, snapshot.roots);
     const skillMd = await readFile(join(sourceDir, "SKILL.md"), "utf8");
     const digest = sha256(skillMd);
 
@@ -156,14 +173,14 @@ export async function promoteSkill(opts: PromoteOptions): Promise<PromoteResult>
       await cp(sourceDir, targetDir, { recursive: true, force: true });
 
       if (target.kind === "boilerplate") {
-        await addSkillToBoilerplateManifest(target.name, opts.skillName, opts.boilerplatesDir);
+        await addSkillToBoilerplateManifest(targetBoilerplate!, opts.skillName);
       }
 
       let index: SkillsIndex;
       try {
         index = await loadRegistry(registryPath);
       } catch {
-        index = await buildRegistryFromCatalog({ registryPath });
+        index = await buildRegistryFromCatalog({ registryPath, snapshot });
       }
 
       const now = new Date().toISOString();
@@ -198,7 +215,14 @@ export async function promoteSkill(opts: PromoteOptions): Promise<PromoteResult>
       const others = index.skills.filter((skill) => skill.id !== id);
       others.push(entry);
       others.sort((a, b) => a.id.localeCompare(b.id));
-      await saveRegistry({ ...index, updatedAt: now, skills: others }, registryPath);
+      const updatedSnapshot = await loadCatalogSnapshot(snapshot.roots);
+      assertValidCatalog(updatedSnapshot);
+      const rebuilt = await buildRegistryFromCatalog({
+        registryPath,
+        existing: { ...index, updatedAt: now, skills: others },
+        snapshot: updatedSnapshot,
+      });
+      await saveRegistry(rebuilt, registryPath);
     }
 
     return {
@@ -216,13 +240,11 @@ export async function promoteSkill(opts: PromoteOptions): Promise<PromoteResult>
 }
 
 async function addSkillToBoilerplateManifest(
-  boilerplateName: string,
+  boilerplate: CatalogBoilerplate,
   skillName: string,
-  boilerplatesDir?: string,
 ): Promise<void> {
-  const bp = await getBoilerplate(boilerplateName, boilerplatesDir);
-  const manifestPath = join(bp.dir, "boilerplate.json");
-  const manifest = bp.manifest;
+  const manifestPath = join(boilerplate.dir, "boilerplate.json");
+  const manifest = { ...boilerplate.manifest, skills: [...boilerplate.manifest.skills] };
   if (manifest.skills.some((s) => s.name === skillName)) return;
   manifest.skills.push({ name: skillName, source: "local" });
   await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");

--- a/src/promote.ts
+++ b/src/promote.ts
@@ -1,10 +1,9 @@
 import { cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { spawn } from "node:child_process";
-import { getBoilerplate, listBoilerplates } from "./catalog.js";
+import { getBoilerplate } from "./catalog.js";
 import {
   buildRegistryFromCatalog,
-  findRegistrySkill,
   loadRegistry,
   saveRegistry,
   type RegistrySkill,
@@ -172,8 +171,13 @@ export async function promoteSkill(opts: PromoteOptions): Promise<PromoteResult>
         target.kind === "shared"
           ? `shared/skills/${opts.skillName}`
           : `boilerplates/${target.name}/skills/${opts.skillName}`;
+      const id =
+        target.kind === "shared"
+          ? `shared:${opts.skillName}`
+          : `boilerplate:${target.name}/skills/${opts.skillName}`;
 
       const entry: RegistrySkill = {
+        id,
         name: opts.skillName,
         catalogLocation: target.kind === "shared" ? "shared" : "local",
         catalogPath,
@@ -191,9 +195,9 @@ export async function promoteSkill(opts: PromoteOptions): Promise<PromoteResult>
         bundledIn: target.kind === "boilerplate" ? [target.name] : [],
       };
 
-      const others = index.skills.filter((s) => s.name !== opts.skillName);
+      const others = index.skills.filter((skill) => skill.id !== id);
       others.push(entry);
-      others.sort((a, b) => a.name.localeCompare(b.name));
+      others.sort((a, b) => a.id.localeCompare(b.id));
       await saveRegistry({ ...index, updatedAt: now, skills: others }, registryPath);
     }
 

--- a/src/promote.ts
+++ b/src/promote.ts
@@ -3,13 +3,14 @@ import { join, resolve } from "node:path";
 import { spawn } from "node:child_process";
 import {
   assertValidCatalog,
+  catalogRootsFromOptions,
   loadCatalogSnapshot,
   type CatalogBoilerplate,
   type CatalogRoots,
 } from "./catalog-snapshot.js";
 import {
   buildRegistryFromCatalog,
-  loadRegistry,
+  loadRegistryIfExists,
   saveRegistry,
   type RegistrySkill,
   type SkillsIndex,
@@ -120,12 +121,7 @@ export async function promoteSkill(opts: PromoteOptions): Promise<PromoteResult>
   const threshold = opts.threshold ?? 30;
   const target = opts.target ?? { kind: "shared" };
   const registryPath = opts.registryPath ?? defaultRegistryPath();
-  const snapshot = await loadCatalogSnapshot({
-    ...opts.catalogRoots,
-    ...(opts.boilerplatesDir ? { boilerplatesDir: opts.boilerplatesDir } : {}),
-    ...(opts.sharedSkillsDir ? { sharedSkillsDir: opts.sharedSkillsDir } : {}),
-    ...(opts.sharedWorkflowsDir ? { sharedWorkflowsDir: opts.sharedWorkflowsDir } : {}),
-  });
+  const snapshot = await loadCatalogSnapshot(catalogRootsFromOptions(opts));
   assertValidCatalog(snapshot);
 
   let targetBoilerplate: CatalogBoilerplate | undefined;
@@ -176,12 +172,9 @@ export async function promoteSkill(opts: PromoteOptions): Promise<PromoteResult>
         await addSkillToBoilerplateManifest(targetBoilerplate!, opts.skillName);
       }
 
-      let index: SkillsIndex;
-      try {
-        index = await loadRegistry(registryPath);
-      } catch {
-        index = await buildRegistryFromCatalog({ registryPath, snapshot });
-      }
+      const index: SkillsIndex =
+        (await loadRegistryIfExists(registryPath)) ??
+        (await buildRegistryFromCatalog({ registryPath, snapshot }));
 
       const now = new Date().toISOString();
       const catalogPath =

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -69,15 +69,33 @@ export interface RegistryOptions {
 function migrateSkillId(skill: z.infer<typeof registrySkillV1Schema>): string {
   if (skill.catalogLocation === "shared") return `shared:${skill.name}`;
 
-  const pathMatch = skill.catalogPath.match(/^boilerplates[/\\]([^/\\]+)[/\\]skills[/\\]/);
-  const onlyBundledOwner = skill.bundledIn.length === 1 ? skill.bundledIn.at(0) : undefined;
-  const boilerplateName = pathMatch?.[1] ?? onlyBundledOwner;
-  if (!boilerplateName) {
+  const pathMatch = skill.catalogPath.match(
+    /^boilerplates[/\\]([^/\\]+)[/\\]skills[/\\]([^/\\]+)\/?$/,
+  );
+  if (pathMatch && pathMatch[2] !== skill.name) {
     throw new Error(
-      `Cannot migrate local registry skill "${skill.name}": catalogPath does not identify a boilerplate and bundledIn is ambiguous`,
+      `Cannot migrate local registry skill "${skill.name}": catalogPath name conflicts`,
     );
   }
+  const owners = new Set<string>([...(pathMatch?.[1] ? [pathMatch[1]] : []), ...skill.bundledIn]);
+  if (owners.size !== 1) {
+    throw new Error(
+      `Cannot migrate local registry skill "${skill.name}": ownership is conflicting or ambiguous`,
+    );
+  }
+  const [boilerplateName] = owners;
   return `boilerplate:${boilerplateName}/skills/${skill.name}`;
+}
+
+export async function loadRegistryIfExists(
+  registryPath = defaultRegistryPath(),
+): Promise<SkillsIndex | null> {
+  try {
+    return await loadRegistry(registryPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
 }
 
 function parseSkillDescription(skillMd: string): string | undefined {
@@ -95,7 +113,7 @@ export async function buildRegistryFromCatalog(
   } = {},
 ): Promise<SkillsIndex> {
   const registryPath = opts.registryPath ?? defaultRegistryPath();
-  const existing = opts.existing ?? (await loadRegistry(registryPath).catch(() => null));
+  const existing = opts.existing ?? (await loadRegistryIfExists(registryPath));
   const existingById = new Map(existing?.skills.map((skill) => [skill.id, skill]) ?? []);
   const defaultThreshold = opts.defaultThreshold ?? 30;
   const snapshot = opts.snapshot ?? (await loadCatalogSnapshot(opts.catalogRoots));

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -70,8 +70,8 @@ function migrateSkillId(skill: z.infer<typeof registrySkillV1Schema>): string {
   if (skill.catalogLocation === "shared") return `shared:${skill.name}`;
 
   const pathMatch = skill.catalogPath.match(/^boilerplates[/\\]([^/\\]+)[/\\]skills[/\\]/);
-  const boilerplateName =
-    pathMatch?.[1] ?? (skill.bundledIn.length === 1 ? skill.bundledIn[0] : null);
+  const onlyBundledOwner = skill.bundledIn.length === 1 ? skill.bundledIn.at(0) : undefined;
+  const boilerplateName = pathMatch?.[1] ?? onlyBundledOwner;
   if (!boilerplateName) {
     throw new Error(
       `Cannot migrate local registry skill "${skill.name}": catalogPath does not identify a boilerplate and bundledIn is ambiguous`,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,8 +1,12 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { z } from "zod";
-import { listCatalogSkillTargets } from "./catalog-scan.js";
-import { listBoilerplates } from "./catalog.js";
+import {
+  assertValidCatalog,
+  loadCatalogSnapshot,
+  type CatalogRoots,
+  type CatalogSnapshot,
+} from "./catalog-snapshot.js";
 import { sha256 } from "./provenance.js";
 import { defaultRegistryPath } from "./paths.js";
 import { scanStatusSchema } from "./schema.js";
@@ -15,7 +19,7 @@ const upstreamSchema = z.object({
   ref: z.string().optional(),
 });
 
-export const registrySkillSchema = z.object({
+const registrySkillV1Schema = z.object({
   name: z.string(),
   /** Where the skill lives in this repo catalog. */
   catalogLocation: z.enum(["shared", "local"]),
@@ -37,10 +41,21 @@ export const registrySkillSchema = z.object({
   bundledIn: z.array(z.string()).default([]),
 });
 
+export const registrySkillSchema = registrySkillV1Schema.extend({
+  /** Stable, scope-qualified identity from the catalog snapshot. */
+  id: z.string().min(1),
+});
+
 export type RegistrySkill = z.infer<typeof registrySkillSchema>;
 
-export const skillsIndexSchema = z.object({
+const skillsIndexV1Schema = z.object({
   indexVersion: z.literal(1),
+  updatedAt: z.string(),
+  skills: z.array(registrySkillV1Schema),
+});
+
+export const skillsIndexSchema = z.object({
+  indexVersion: z.literal(2),
   updatedAt: z.string(),
   skills: z.array(registrySkillSchema),
 });
@@ -49,6 +64,20 @@ export type SkillsIndex = z.infer<typeof skillsIndexSchema>;
 
 export interface RegistryOptions {
   registryPath?: string;
+}
+
+function migrateSkillId(skill: z.infer<typeof registrySkillV1Schema>): string {
+  if (skill.catalogLocation === "shared") return `shared:${skill.name}`;
+
+  const pathMatch = skill.catalogPath.match(/^boilerplates[/\\]([^/\\]+)[/\\]skills[/\\]/);
+  const boilerplateName =
+    pathMatch?.[1] ?? (skill.bundledIn.length === 1 ? skill.bundledIn[0] : null);
+  if (!boilerplateName) {
+    throw new Error(
+      `Cannot migrate local registry skill "${skill.name}": catalogPath does not identify a boilerplate and bundledIn is ambiguous`,
+    );
+  }
+  return `boilerplate:${boilerplateName}/skills/${skill.name}`;
 }
 
 function parseSkillDescription(skillMd: string): string | undefined {
@@ -61,41 +90,41 @@ export async function buildRegistryFromCatalog(
   opts: RegistryOptions & {
     existing?: SkillsIndex;
     defaultThreshold?: number;
+    snapshot?: CatalogSnapshot;
+    catalogRoots?: Partial<CatalogRoots>;
   } = {},
 ): Promise<SkillsIndex> {
   const registryPath = opts.registryPath ?? defaultRegistryPath();
   const existing = opts.existing ?? (await loadRegistry(registryPath).catch(() => null));
-  const existingByName = new Map(existing?.skills.map((s) => [s.name, s]) ?? []);
+  const existingById = new Map(existing?.skills.map((skill) => [skill.id, skill]) ?? []);
   const defaultThreshold = opts.defaultThreshold ?? 30;
-
-  const boilerplates = await listBoilerplates();
-  const bundledInBySkill = new Map<string, Set<string>>();
-  for (const bp of boilerplates) {
-    for (const skill of bp.manifest.skills) {
-      const set = bundledInBySkill.get(skill.name) ?? new Set<string>();
-      set.add(bp.manifest.name);
-      bundledInBySkill.set(skill.name, set);
-    }
-  }
-
-  const targets = await listCatalogSkillTargets();
+  const snapshot = opts.snapshot ?? (await loadCatalogSnapshot(opts.catalogRoots));
+  assertValidCatalog(snapshot);
   const skills: RegistrySkill[] = [];
 
-  for (const target of targets) {
-    const skillName = target.dir.split("/").pop() ?? target.id;
-    const isShared = target.label.startsWith("shared/");
-    const catalogLocation = isShared ? ("shared" as const) : ("local" as const);
-    const catalogPath = isShared
-      ? `shared/skills/${skillName}`
-      : target.label
-          .replace(/^boilerplate\//, "boilerplates/")
-          .replace(/\/[^/]+$/, `/skills/${skillName}`);
-
-    const skillMd = await readFile(join(target.dir, "SKILL.md"), "utf8");
-    const prev = existingByName.get(skillName);
+  for (const skill of snapshot.skills) {
+    const catalogLocation = skill.scope === "shared" ? ("shared" as const) : ("local" as const);
+    const catalogPath =
+      skill.scope === "shared"
+        ? `shared/skills/${skill.name}`
+        : `boilerplates/${skill.boilerplateName}/skills/${skill.name}`;
+    const declaredIn = snapshot.boilerplates
+      .filter((boilerplate) =>
+        boilerplate.manifest.skills.some(
+          (declaration) =>
+            declaration.name === skill.name &&
+            declaration.source === skill.scope &&
+            (skill.scope === "shared" || boilerplate.manifest.name === skill.boilerplateName),
+        ),
+      )
+      .map((boilerplate) => boilerplate.manifest.name)
+      .sort();
+    const skillMd = await readFile(join(skill.dir, "SKILL.md"), "utf8");
+    const prev = existingById.get(skill.id);
 
     skills.push({
-      name: skillName,
+      id: skill.id,
+      name: skill.name,
       catalogLocation,
       catalogPath,
       description: parseSkillDescription(skillMd) ?? prev?.description,
@@ -111,14 +140,14 @@ export async function buildRegistryFromCatalog(
       },
       bundleAll: prev?.bundleAll ?? false,
       bundledIn: prev?.bundleAll
-        ? boilerplates.map((b) => b.manifest.name)
-        : [...(bundledInBySkill.get(skillName) ?? [])].sort(),
+        ? snapshot.boilerplates.map((boilerplate) => boilerplate.manifest.name).sort()
+        : declaredIn,
     });
   }
 
-  skills.sort((a, b) => a.name.localeCompare(b.name));
+  skills.sort((a, b) => a.id.localeCompare(b.id));
   return {
-    indexVersion: 1,
+    indexVersion: 2,
     updatedAt: new Date().toISOString(),
     skills,
   };
@@ -126,7 +155,18 @@ export async function buildRegistryFromCatalog(
 
 export async function loadRegistry(registryPath = defaultRegistryPath()): Promise<SkillsIndex> {
   const raw = await readFile(registryPath, "utf8");
-  return skillsIndexSchema.parse(JSON.parse(raw));
+  const parsed = JSON.parse(raw) as unknown;
+  const version = z.object({ indexVersion: z.number() }).parse(parsed).indexVersion;
+  if (version === 2) return skillsIndexSchema.parse(parsed);
+  if (version === 1) {
+    const legacy = skillsIndexV1Schema.parse(parsed);
+    return skillsIndexSchema.parse({
+      indexVersion: 2,
+      updatedAt: legacy.updatedAt,
+      skills: legacy.skills.map((skill) => ({ ...skill, id: migrateSkillId(skill) })),
+    });
+  }
+  throw new Error(`Unsupported registry index version: ${version}`);
 }
 
 export async function saveRegistry(
@@ -143,16 +183,9 @@ export function applyCatalogScanToRegistry(
   index: SkillsIndex,
   scanResults: Array<{ id: string; label: string; riskScore: number | null; status: string }>,
 ): SkillsIndex {
-  const byLabel = new Map(scanResults.map((r) => [r.label, r]));
+  const byId = new Map(scanResults.map((result) => [result.id, result]));
   const skills = index.skills.map((skill) => {
-    const label =
-      skill.catalogLocation === "shared"
-        ? `shared/${skill.name}`
-        : skill.bundledIn[0]
-          ? `boilerplate/${skill.bundledIn[0]}/${skill.name}`
-          : null;
-    if (!label) return skill;
-    const scan = byLabel.get(label);
+    const scan = byId.get(skill.id);
     if (!scan || scan.riskScore === null) return skill;
     const status: ScanStatus =
       scan.status === "passed" ? "passed" : scan.status === "failed" ? "failed" : "skipped";
@@ -169,6 +202,6 @@ export function applyCatalogScanToRegistry(
   return { ...index, updatedAt: new Date().toISOString(), skills };
 }
 
-export function findRegistrySkill(index: SkillsIndex, name: string): RegistrySkill | undefined {
-  return index.skills.find((s) => s.name === name);
+export function findRegistrySkill(index: SkillsIndex, id: string): RegistrySkill | undefined {
+  return index.skills.find((skill) => skill.id === id);
 }

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -2,6 +2,7 @@ import { cp, mkdir, readdir, rename, readFile, stat, appendFile } from "node:fs/
 import { join, relative } from "node:path";
 import {
   assertValidCatalog,
+  catalogRootsFromOptions,
   loadCatalogSnapshot,
   type CatalogBoilerplate,
   type CatalogRoots,
@@ -97,10 +98,7 @@ function resolveManifestWorkflow(
 
 export async function scaffold(options: ScaffoldOptions): Promise<ScaffoldResult> {
   const { boilerplateName, targetDir, agents } = options;
-  const snapshot = await loadCatalogSnapshot({
-    ...options.catalogRoots,
-    ...(options.boilerplatesDir ? { boilerplatesDir: options.boilerplatesDir } : {}),
-  });
+  const snapshot = await loadCatalogSnapshot(catalogRootsFromOptions(options));
   assertValidCatalog(snapshot);
   const boilerplate = snapshot.boilerplates.find(
     (entry) => entry.manifest.name === boilerplateName,

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -1,16 +1,16 @@
 import { cp, mkdir, readdir, rename, readFile, stat, appendFile } from "node:fs/promises";
 import { join, relative } from "node:path";
-import { getBoilerplate } from "./catalog.js";
+import {
+  assertValidCatalog,
+  loadCatalogSnapshot,
+  type CatalogBoilerplate,
+  type CatalogRoots,
+  type CatalogSnapshot,
+} from "./catalog-snapshot.js";
 import { AGENT_TARGETS, type AgentId } from "./agents.js";
 import { sha256, writeLock } from "./provenance.js";
 import type { LockedSkill, SkillsLock } from "./schema.js";
-import { defaultBoilerplatesDir, defaultSharedSkillsDir } from "./paths.js";
-import { assertSkillExists, resolveSkillDirectory, skillLockSource } from "./skills.js";
-import {
-  assertWorkflowExists,
-  resolveWorkflowDirectory,
-  workflowAgentsSnippet,
-} from "./workflows.js";
+import { workflowAgentsSnippet } from "./workflows.js";
 import {
   defaultPluginDir,
   listSkillSources,
@@ -26,6 +26,7 @@ export interface ScaffoldOptions {
   targetDir: string;
   agents: AgentId[];
   boilerplatesDir?: string;
+  catalogRoots?: Partial<CatalogRoots>;
   /** Override manifest workflow by name, or false to skip. */
   workflow?: string | false;
 }
@@ -64,7 +65,6 @@ async function installWorkflow(
   workflowName: string,
   sourceDir: string,
 ): Promise<string> {
-  await assertWorkflowExists(sourceDir, workflowName);
   const destDir = join(targetDir, "workflows", workflowName);
   await mkdir(join(targetDir, "workflows"), { recursive: true });
   await cp(sourceDir, destDir, { recursive: true });
@@ -72,7 +72,8 @@ async function installWorkflow(
 }
 
 function resolveManifestWorkflow(
-  boilerplate: Awaited<ReturnType<typeof getBoilerplate>>,
+  snapshot: CatalogSnapshot,
+  boilerplate: CatalogBoilerplate,
   workflowOverride: string | false | undefined,
 ): { name: string; sourceDir: string } | undefined {
   if (workflowOverride === false) return undefined;
@@ -80,27 +81,35 @@ function resolveManifestWorkflow(
   const manifestWorkflow = boilerplate.manifest.workflow;
   if (workflowOverride) {
     const source = manifestWorkflow?.source ?? "shared";
-    const workflow = { name: workflowOverride, source };
-    const sourceDir = resolveWorkflowDirectory(workflow, {
-      boilerplateName: boilerplate.manifest.name,
-      boilerplateDir: boilerplate.dir,
-    });
-    return { name: workflowOverride, sourceDir };
+    const id =
+      source === "shared"
+        ? `shared:workflows/${workflowOverride}`
+        : `boilerplate:${boilerplate.manifest.name}/workflow/${workflowOverride}`;
+    const workflow = snapshot.workflows.find((entry) => entry.id === id);
+    if (!workflow) throw new Error(`Unknown workflow: ${id}`);
+    return { name: workflow.name, sourceDir: workflow.dir };
   }
 
-  if (!manifestWorkflow) return undefined;
-
-  const sourceDir = resolveWorkflowDirectory(manifestWorkflow, {
-    boilerplateName: boilerplate.manifest.name,
-    boilerplateDir: boilerplate.dir,
-  });
-  return { name: manifestWorkflow.name, sourceDir };
+  return boilerplate.workflow
+    ? { name: boilerplate.workflow.name, sourceDir: boilerplate.workflow.dir }
+    : undefined;
 }
 
 export async function scaffold(options: ScaffoldOptions): Promise<ScaffoldResult> {
   const { boilerplateName, targetDir, agents } = options;
-  const boilerplatesDir = options.boilerplatesDir ?? defaultBoilerplatesDir();
-  const boilerplate = await getBoilerplate(boilerplateName, boilerplatesDir);
+  const snapshot = await loadCatalogSnapshot({
+    ...options.catalogRoots,
+    ...(options.boilerplatesDir ? { boilerplatesDir: options.boilerplatesDir } : {}),
+  });
+  assertValidCatalog(snapshot);
+  const boilerplate = snapshot.boilerplates.find(
+    (entry) => entry.manifest.name === boilerplateName,
+  );
+  if (!boilerplate) {
+    const available =
+      snapshot.boilerplates.map((entry) => entry.manifest.name).join(", ") || "(none)";
+    throw new Error(`Unknown boilerplate: "${boilerplateName}". Available: ${available}.`);
+  }
 
   await assertUsableTarget(targetDir);
   await mkdir(targetDir, { recursive: true });
@@ -117,17 +126,9 @@ export async function scaffold(options: ScaffoldOptions): Promise<ScaffoldResult
 
   const lockedSkills: LockedSkill[] = [];
 
-  const catalogPaths = {
-    boilerplateName: boilerplate.manifest.name,
-    boilerplateSkillsDir: boilerplate.skillsDir,
-    sharedSkillsDir: defaultSharedSkillsDir(),
-  };
-
-  for (const skill of boilerplate.manifest.skills) {
-    const sourceSkillDir = resolveSkillDirectory(skill, catalogPaths);
-    await assertSkillExists(sourceSkillDir, skill.name);
+  for (const skill of boilerplate.skills) {
     const canonicalDir = join(canonicalRoot, skill.name);
-    await cp(sourceSkillDir, canonicalDir, { recursive: true });
+    await cp(skill.dir, canonicalDir, { recursive: true });
 
     const skillMd = await readFile(join(canonicalDir, "SKILL.md"), "utf8");
 
@@ -145,7 +146,7 @@ export async function scaffold(options: ScaffoldOptions): Promise<ScaffoldResult
 
     lockedSkills.push({
       name: skill.name,
-      source: skillLockSource(skill, boilerplate.manifest.name),
+      source: skill.id,
       sha256: sha256(skillMd),
       installedTo,
       scan: {
@@ -169,7 +170,7 @@ export async function scaffold(options: ScaffoldOptions): Promise<ScaffoldResult
 
   let workflowPath: string | undefined;
   let workflowName: string | undefined;
-  const resolved = resolveManifestWorkflow(boilerplate, options.workflow);
+  const resolved = resolveManifestWorkflow(snapshot, boilerplate, options.workflow);
   if (resolved) {
     workflowName = resolved.name;
     workflowPath = await installWorkflow(targetDir, resolved.name, resolved.sourceDir);

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2,14 +2,12 @@ import { z } from "zod";
 import { KNOWN_AGENTS } from "./agents.js";
 
 const agentEnum = z.enum(KNOWN_AGENTS as [string, ...string[]]);
+const catalogNameSchema = z
+  .string()
+  .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, "name must be lowercase-hyphen-case");
 
 export const boilerplateManifestSchema = z.object({
-  name: z
-    .string()
-    .regex(
-      /^[a-z0-9]+(-[a-z0-9]+)*$/,
-      "name must be lowercase alphanumeric words separated by single hyphens",
-    ),
+  name: catalogNameSchema,
   description: z.string().min(1).max(1024),
   stack: z.string().min(1),
   version: z.string().min(1),
@@ -17,9 +15,7 @@ export const boilerplateManifestSchema = z.object({
   skills: z
     .array(
       z.object({
-        name: z
-          .string()
-          .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, "skill name must be lowercase-hyphen-case"),
+        name: catalogNameSchema,
         /** `local` = boilerplates/<name>/skills/; `shared` = shared/skills/ (catalog-only). */
         source: z.enum(["local", "shared"]).default("local"),
       }),
@@ -27,9 +23,7 @@ export const boilerplateManifestSchema = z.object({
     .default([]),
   workflow: z
     .object({
-      name: z
-        .string()
-        .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, "workflow name must be lowercase-hyphen-case"),
+      name: catalogNameSchema,
       /** `local` → boilerplates/<name>/workflow/; `shared` → shared/workflows/ (catalog-only). */
       source: z.enum(["local", "shared"]).default("shared"),
     })
@@ -37,6 +31,38 @@ export const boilerplateManifestSchema = z.object({
 });
 
 export type BoilerplateManifest = z.infer<typeof boilerplateManifestSchema>;
+
+export const workflowManifestSchema = z
+  .object({
+    schemaVersion: z.string().min(1),
+    name: catalogNameSchema,
+    version: z.string().min(1),
+    description: z.string().min(1),
+    skills: z.array(z.object({ source: z.string().min(1), repo: z.string().min(1).optional() })),
+    steps: z.array(
+      z.object({
+        id: z.string().min(1),
+        title: z.string().min(1),
+        skill: z.string().min(1),
+        gate: z.string().min(1).optional(),
+      }),
+    ),
+  })
+  .superRefine((workflow, ctx) => {
+    const seen = new Set<string>();
+    for (const [index, step] of workflow.steps.entries()) {
+      if (seen.has(step.id)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["steps", index, "id"],
+          message: "step id must be unique",
+        });
+      }
+      seen.add(step.id);
+    }
+  });
+
+export type WorkflowManifest = z.infer<typeof workflowManifestSchema>;
 
 export const scanStatusSchema = z.enum(["pending", "passed", "failed", "skipped"]);
 export type ScanStatus = z.infer<typeof scanStatusSchema>;

--- a/src/sync-skills.ts
+++ b/src/sync-skills.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { listBoilerplates } from "./catalog.js";
+import { assertValidCatalog, loadCatalogSnapshot, type CatalogRoots } from "./catalog-snapshot.js";
 import {
   buildRegistryFromCatalog,
   loadRegistry,
@@ -14,6 +14,9 @@ import type { BoilerplateManifest } from "./schema.js";
 export interface SyncSkillsOptions {
   registryPath?: string;
   boilerplatesDir?: string;
+  sharedSkillsDir?: string;
+  sharedWorkflowsDir?: string;
+  catalogRoots?: Partial<CatalogRoots>;
   dryRun?: boolean;
 }
 
@@ -36,17 +39,24 @@ function skillsToBundle(skill: RegistrySkill, allBoilerplateNames: string[]): st
 
 export async function syncSkills(opts: SyncSkillsOptions = {}): Promise<SyncSkillsResult> {
   const registryPath = opts.registryPath ?? defaultRegistryPath();
-  const boilerplatesDir = opts.boilerplatesDir ?? defaultBoilerplatesDir();
   const dryRun = Boolean(opts.dryRun);
+  const catalogRoots: Partial<CatalogRoots> = {
+    ...opts.catalogRoots,
+    ...(opts.boilerplatesDir ? { boilerplatesDir: opts.boilerplatesDir } : {}),
+    ...(opts.sharedSkillsDir ? { sharedSkillsDir: opts.sharedSkillsDir } : {}),
+    ...(opts.sharedWorkflowsDir ? { sharedWorkflowsDir: opts.sharedWorkflowsDir } : {}),
+  };
+  let snapshot = await loadCatalogSnapshot(catalogRoots);
+  assertValidCatalog(snapshot);
 
   let index: SkillsIndex;
   try {
     index = await loadRegistry(registryPath);
   } catch {
-    index = await buildRegistryFromCatalog({ registryPath });
+    index = await buildRegistryFromCatalog({ registryPath, snapshot });
   }
 
-  const boilerplates = await listBoilerplates(boilerplatesDir);
+  const boilerplates = snapshot.boilerplates;
   const allNames = boilerplates.map((b) => b.manifest.name);
   const addedToBoilerplates: SyncSkillsResult["addedToBoilerplates"] = [];
 
@@ -71,7 +81,11 @@ export async function syncSkills(opts: SyncSkillsOptions = {}): Promise<SyncSkil
     }
   }
 
-  const rebuilt = await buildRegistryFromCatalog({ registryPath, existing: index });
+  if (!dryRun) {
+    snapshot = await loadCatalogSnapshot(catalogRoots);
+    assertValidCatalog(snapshot);
+  }
+  const rebuilt = await buildRegistryFromCatalog({ registryPath, existing: index, snapshot });
   if (!dryRun) {
     await saveRegistry(rebuilt, registryPath);
   }
@@ -89,9 +103,9 @@ export async function readBoilerplateManifest(
   boilerplateName: string,
   boilerplatesDir = defaultBoilerplatesDir(),
 ): Promise<BoilerplateManifest> {
-  const bp = (await listBoilerplates(boilerplatesDir)).find(
-    (b) => b.manifest.name === boilerplateName,
-  );
+  const snapshot = await loadCatalogSnapshot({ boilerplatesDir });
+  assertValidCatalog(snapshot);
+  const bp = snapshot.boilerplates.find((b) => b.manifest.name === boilerplateName);
   if (!bp) throw new Error(`Unknown boilerplate: ${boilerplateName}`);
   const raw = await readFile(join(bp.dir, "boilerplate.json"), "utf8");
   return JSON.parse(raw) as BoilerplateManifest;

--- a/src/sync-skills.ts
+++ b/src/sync-skills.ts
@@ -1,9 +1,14 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { assertValidCatalog, loadCatalogSnapshot, type CatalogRoots } from "./catalog-snapshot.js";
+import {
+  assertValidCatalog,
+  catalogRootsFromOptions,
+  loadCatalogSnapshot,
+  type CatalogRoots,
+} from "./catalog-snapshot.js";
 import {
   buildRegistryFromCatalog,
-  loadRegistry,
+  loadRegistryIfExists,
   saveRegistry,
   type RegistrySkill,
   type SkillsIndex,
@@ -27,7 +32,10 @@ export interface SyncSkillsResult {
   dryRun: boolean;
 }
 
-function manifestHasSkill(manifest: BoilerplateManifest, skillName: string): boolean {
+function manifestHasSkill(
+  manifest: { readonly skills: readonly { readonly name: string }[] },
+  skillName: string,
+): boolean {
   return manifest.skills.some((s) => s.name === skillName);
 }
 
@@ -40,21 +48,13 @@ function skillsToBundle(skill: RegistrySkill, allBoilerplateNames: string[]): st
 export async function syncSkills(opts: SyncSkillsOptions = {}): Promise<SyncSkillsResult> {
   const registryPath = opts.registryPath ?? defaultRegistryPath();
   const dryRun = Boolean(opts.dryRun);
-  const catalogRoots: Partial<CatalogRoots> = {
-    ...opts.catalogRoots,
-    ...(opts.boilerplatesDir ? { boilerplatesDir: opts.boilerplatesDir } : {}),
-    ...(opts.sharedSkillsDir ? { sharedSkillsDir: opts.sharedSkillsDir } : {}),
-    ...(opts.sharedWorkflowsDir ? { sharedWorkflowsDir: opts.sharedWorkflowsDir } : {}),
-  };
+  const catalogRoots = catalogRootsFromOptions(opts);
   let snapshot = await loadCatalogSnapshot(catalogRoots);
   assertValidCatalog(snapshot);
 
-  let index: SkillsIndex;
-  try {
-    index = await loadRegistry(registryPath);
-  } catch {
-    index = await buildRegistryFromCatalog({ registryPath, snapshot });
-  }
+  const index: SkillsIndex =
+    (await loadRegistryIfExists(registryPath)) ??
+    (await buildRegistryFromCatalog({ registryPath, snapshot }));
 
   const boilerplates = snapshot.boilerplates;
   const allNames = boilerplates.map((b) => b.manifest.name);

--- a/src/upstream-sync.ts
+++ b/src/upstream-sync.ts
@@ -2,7 +2,8 @@ import { cp, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { cleanupClone, cloneGitRepo, findSkillDirectory } from "./git.js";
 import { sha256 } from "./provenance.js";
-import { defaultRegistryPath, defaultSharedSkillsDir } from "./paths.js";
+import { defaultRegistryPath } from "./paths.js";
+import { assertValidCatalog, loadCatalogSnapshot, type CatalogRoots } from "./catalog-snapshot.js";
 import {
   buildRegistryFromCatalog,
   loadRegistry,
@@ -15,6 +16,9 @@ import { scanSkillDirectory, type SkillScanner } from "./scan.js";
 export interface UpstreamSyncOptions {
   registryPath?: string;
   sharedSkillsDir?: string;
+  boilerplatesDir?: string;
+  sharedWorkflowsDir?: string;
+  catalogRoots?: Partial<CatalogRoots>;
   scanner: SkillScanner;
   threshold?: number;
   requireScanner?: boolean;
@@ -51,16 +55,33 @@ async function readSkillSha(skillDir: string): Promise<string> {
 
 export async function syncUpstreamSkills(opts: UpstreamSyncOptions): Promise<UpstreamSyncResult> {
   const registryPath = opts.registryPath ?? defaultRegistryPath();
-  const sharedSkillsDir = opts.sharedSkillsDir ?? defaultSharedSkillsDir();
   const threshold = opts.threshold ?? 30;
   const apply = Boolean(opts.apply);
   const dryRun = Boolean(opts.dryRun);
+  const catalogRoots: Partial<CatalogRoots> = {
+    ...opts.catalogRoots,
+    ...(opts.boilerplatesDir ? { boilerplatesDir: opts.boilerplatesDir } : {}),
+    ...(opts.sharedSkillsDir ? { sharedSkillsDir: opts.sharedSkillsDir } : {}),
+    ...(opts.sharedWorkflowsDir ? { sharedWorkflowsDir: opts.sharedWorkflowsDir } : {}),
+  };
+  let snapshot = await loadCatalogSnapshot(catalogRoots);
+  assertValidCatalog(snapshot);
 
   let index: SkillsIndex;
   try {
     index = await loadRegistry(registryPath);
   } catch {
-    index = await buildRegistryFromCatalog({ registryPath });
+    index = await buildRegistryFromCatalog({ registryPath, snapshot });
+  }
+
+  const selectedSkills = index.skills.filter(
+    (skill) =>
+      skill.catalogLocation === "shared" &&
+      skill.id === `shared:${skill.name}` &&
+      (!opts.skillName || skill.name === opts.skillName),
+  );
+  if (opts.skillName && selectedSkills.length > 1) {
+    throw new Error(`Ambiguous shared skill name: ${opts.skillName}`);
   }
 
   const available = await opts.scanner.isAvailable();
@@ -74,20 +95,15 @@ export async function syncUpstreamSkills(opts: UpstreamSyncOptions): Promise<Ups
   const entries: UpstreamSyncEntry[] = [];
   let indexChanged = false;
 
-  for (const skill of index.skills) {
-    if (opts.skillName && skill.name !== opts.skillName) continue;
+  for (const skill of selectedSkills) {
     if (!skillHasUpstream(skill)) continue;
-    if (skill.catalogLocation !== "shared") {
-      entries.push({
-        name: skill.name,
-        status: "skipped",
-        message: "upstream sync applies to shared catalog skills only",
-      });
-      continue;
-    }
 
     const upstream = skill.upstream!;
-    const localDir = join(sharedSkillsDir, skill.name);
+    const catalogSkill = snapshot.skills.find((entry) => entry.id === skill.id);
+    if (!catalogSkill) {
+      throw new Error(`Registry skill is missing from the catalog snapshot: ${skill.id}`);
+    }
+    const localDir = catalogSkill.dir;
     let localDigest: string;
     try {
       localDigest = await readSkillSha(localDir);
@@ -142,8 +158,7 @@ export async function syncUpstreamSkills(opts: UpstreamSyncOptions): Promise<Ups
         }
       }
 
-      const targetDir = join(sharedSkillsDir, skill.name);
-      await cp(upstreamSkillDir, targetDir, { recursive: true, force: true });
+      await cp(upstreamSkillDir, localDir, { recursive: true, force: true });
       const now = new Date().toISOString();
       skill.sha256 = upstreamDigest;
       skill.upstream = { ...upstream, ref: cloned.resolvedRef };
@@ -175,7 +190,9 @@ export async function syncUpstreamSkills(opts: UpstreamSyncOptions): Promise<Ups
   }
 
   if (indexChanged && !dryRun) {
-    const rebuilt = await buildRegistryFromCatalog({ registryPath, existing: index });
+    snapshot = await loadCatalogSnapshot(catalogRoots);
+    assertValidCatalog(snapshot);
+    const rebuilt = await buildRegistryFromCatalog({ registryPath, existing: index, snapshot });
     await saveRegistry(rebuilt, registryPath);
   }
 

--- a/src/upstream-sync.ts
+++ b/src/upstream-sync.ts
@@ -3,10 +3,15 @@ import { join } from "node:path";
 import { cleanupClone, cloneGitRepo, findSkillDirectory } from "./git.js";
 import { sha256 } from "./provenance.js";
 import { defaultRegistryPath } from "./paths.js";
-import { assertValidCatalog, loadCatalogSnapshot, type CatalogRoots } from "./catalog-snapshot.js";
+import {
+  assertValidCatalog,
+  catalogRootsFromOptions,
+  loadCatalogSnapshot,
+  type CatalogRoots,
+} from "./catalog-snapshot.js";
 import {
   buildRegistryFromCatalog,
-  loadRegistry,
+  loadRegistryIfExists,
   saveRegistry,
   type RegistrySkill,
   type SkillsIndex,
@@ -58,21 +63,13 @@ export async function syncUpstreamSkills(opts: UpstreamSyncOptions): Promise<Ups
   const threshold = opts.threshold ?? 30;
   const apply = Boolean(opts.apply);
   const dryRun = Boolean(opts.dryRun);
-  const catalogRoots: Partial<CatalogRoots> = {
-    ...opts.catalogRoots,
-    ...(opts.boilerplatesDir ? { boilerplatesDir: opts.boilerplatesDir } : {}),
-    ...(opts.sharedSkillsDir ? { sharedSkillsDir: opts.sharedSkillsDir } : {}),
-    ...(opts.sharedWorkflowsDir ? { sharedWorkflowsDir: opts.sharedWorkflowsDir } : {}),
-  };
+  const catalogRoots = catalogRootsFromOptions(opts);
   let snapshot = await loadCatalogSnapshot(catalogRoots);
   assertValidCatalog(snapshot);
 
-  let index: SkillsIndex;
-  try {
-    index = await loadRegistry(registryPath);
-  } catch {
-    index = await buildRegistryFromCatalog({ registryPath, snapshot });
-  }
+  const index: SkillsIndex =
+    (await loadRegistryIfExists(registryPath)) ??
+    (await buildRegistryFromCatalog({ registryPath, snapshot }));
 
   const selectedSkills = index.skills.filter(
     (skill) =>

--- a/tests/catalog-fixture.ts
+++ b/tests/catalog-fixture.ts
@@ -1,0 +1,61 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface CatalogFixture {
+  root: string;
+  boilerplatesDir: string;
+  sharedSkillsDir: string;
+  sharedWorkflowsDir: string;
+}
+
+export async function createCatalogFixture(root: string): Promise<CatalogFixture> {
+  const fixture = {
+    root,
+    boilerplatesDir: join(root, "boilerplates"),
+    sharedSkillsDir: join(root, "shared", "skills"),
+    sharedWorkflowsDir: join(root, "shared", "workflows"),
+  };
+  await Promise.all([
+    mkdir(fixture.boilerplatesDir, { recursive: true }),
+    mkdir(fixture.sharedSkillsDir, { recursive: true }),
+    mkdir(fixture.sharedWorkflowsDir, { recursive: true }),
+  ]);
+  return fixture;
+}
+
+export async function writeSkill(dir: string, name: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: Use when testing ${name} catalog behavior.\nlicense: MIT\n---\n\n# ${name}\n`,
+    "utf8",
+  );
+}
+
+export async function writeBoilerplate(
+  fixture: CatalogFixture,
+  directoryName: string,
+  manifest: Record<string, unknown>,
+): Promise<string> {
+  const dir = join(fixture.boilerplatesDir, directoryName);
+  await mkdir(join(dir, "template"), { recursive: true });
+  await mkdir(join(dir, "skills"), { recursive: true });
+  await writeFile(join(dir, "boilerplate.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  return dir;
+}
+
+export function boilerplateManifest(
+  name: string,
+  skills: Array<{ name: string; source: "local" | "shared" }> = [],
+  workflow?: { name: string; source: "local" | "shared" },
+): Record<string, unknown> {
+  return {
+    name,
+    description: `${name} test boilerplate`,
+    stack: "test",
+    version: "1.0.0",
+    defaultAgents: ["claude"],
+    skills,
+    ...(workflow ? { workflow } : {}),
+  };
+}

--- a/tests/catalog-fixture.ts
+++ b/tests/catalog-fixture.ts
@@ -59,3 +59,21 @@ export function boilerplateManifest(
     ...(workflow ? { workflow } : {}),
   };
 }
+
+export async function writeWorkflow(
+  dir: string,
+  name: string,
+  overrides: Record<string, unknown> = {},
+): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  const manifest = {
+    schemaVersion: "0.1",
+    name,
+    version: "1.0.0",
+    description: `${name} test workflow`,
+    skills: [{ source: "./skills/demo" }],
+    steps: [{ id: "deliver", title: "Deliver", skill: "demo" }],
+    ...overrides,
+  };
+  await writeFile(join(dir, "workflow.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}

--- a/tests/catalog-scan.test.ts
+++ b/tests/catalog-scan.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { listCatalogSkillTargets, scanCatalog } from "../src/catalog-scan.js";
 import type { SkillScanner } from "../src/scan.js";
+import { CatalogValidationError } from "../src/catalog-snapshot.js";
+import { boilerplateManifest, createCatalogFixture, writeBoilerplate } from "./catalog-fixture.js";
 
 function fakeScanner(opts: {
   available: boolean;
@@ -40,11 +42,11 @@ async function exists(path: string): Promise<boolean> {
 describe("catalog scan", () => {
   it("discovers shared and local catalog skills", async () => {
     const targets = await listCatalogSkillTargets();
-    const labels = targets.map((t) => t.label);
-    expect(labels).toEqual(
-      expect.arrayContaining(["shared/code-review", "shared/test-driven-development"]),
+    const ids = targets.map((target) => target.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(["shared:code-review", "shared:test-driven-development"]),
     );
-    expect(labels.some((l) => l.startsWith("boilerplate/"))).toBe(true);
+    expect(ids.some((id) => id.startsWith("boilerplate:") && id.includes("/skills/"))).toBe(true);
   });
 
   describe("scanCatalog", () => {
@@ -100,6 +102,31 @@ describe("catalog scan", () => {
           reportsDir,
         }),
       ).rejects.toThrow(/not installed/);
+    });
+
+    it("rejects invalid catalog relationships before invoking the scanner", async () => {
+      const fixture = await createCatalogFixture(join(reportsDir, "catalog"));
+      await writeBoilerplate(
+        fixture,
+        "demo",
+        boilerplateManifest("demo", [{ name: "missing", source: "shared" }]),
+      );
+      let scanCalls = 0;
+      const scanner: SkillScanner = {
+        name: "spy",
+        async isAvailable() {
+          return true;
+        },
+        async scan() {
+          scanCalls += 1;
+          return { riskScore: 0, scanMode: "static", findings: 0 };
+        },
+      };
+
+      await expect(scanCatalog({ scanner, reportsDir, ...fixture })).rejects.toBeInstanceOf(
+        CatalogValidationError,
+      );
+      expect(scanCalls).toBe(0);
     });
   });
 });

--- a/tests/catalog-snapshot.test.ts
+++ b/tests/catalog-snapshot.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadCatalogSnapshot } from "../src/catalog-snapshot.js";
+import {
+  boilerplateManifest,
+  createCatalogFixture,
+  writeBoilerplate,
+  writeSkill,
+} from "./catalog-fixture.js";
+
+const roots: string[] = [];
+
+async function newRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "bwai-catalog-snapshot-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("loadCatalogSnapshot", () => {
+  it("loads valid artifacts with canonical identities and freezes the result", async () => {
+    const fixture = await createCatalogFixture(await newRoot());
+    await writeSkill(join(fixture.sharedSkillsDir, "code-review"), "code-review");
+    await writeBoilerplate(
+      fixture,
+      "demo",
+      boilerplateManifest("demo", [{ name: "code-review", source: "shared" }]),
+    );
+
+    const snapshot = await loadCatalogSnapshot(fixture);
+
+    expect(snapshot.valid).toBe(true);
+    expect(snapshot.skills.map((skill) => skill.id)).toContain("shared:code-review");
+    expect(snapshot.boilerplates.map((boilerplate) => boilerplate.id)).toContain(
+      "boilerplate:demo",
+    );
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.skills)).toBe(true);
+  });
+
+  it("retains malformed boilerplate discoveries and reports a diagnostic", async () => {
+    const fixture = await createCatalogFixture(await newRoot());
+    const dir = join(fixture.boilerplatesDir, "broken");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "boilerplate.json"), "{not-json", "utf8");
+
+    const snapshot = await loadCatalogSnapshot(fixture);
+
+    expect(snapshot.valid).toBe(false);
+    expect(snapshot.artifacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "boilerplate", path: dir, valid: false }),
+      ]),
+    );
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+      "INVALID_BOILERPLATE_MANIFEST",
+    );
+  });
+
+  it("turns unreadable catalog roots into diagnostics", async () => {
+    const root = await newRoot();
+    const snapshot = await loadCatalogSnapshot({
+      boilerplatesDir: join(root, "missing-boilerplates"),
+      sharedSkillsDir: join(root, "missing-skills"),
+      sharedWorkflowsDir: join(root, "missing-workflows"),
+    });
+
+    expect(snapshot.valid).toBe(false);
+    expect(
+      snapshot.diagnostics.filter((diagnostic) => diagnostic.code === "CATALOG_ROOT_UNREADABLE"),
+    ).toHaveLength(3);
+  });
+});

--- a/tests/catalog-snapshot.test.ts
+++ b/tests/catalog-snapshot.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   assertValidCatalog,
   CatalogValidationError,
+  formatCatalogError,
   loadCatalogSnapshot,
   type CatalogDiagnosticCode,
 } from "../src/catalog-snapshot.js";
@@ -47,6 +48,8 @@ describe("loadCatalogSnapshot", () => {
     );
     expect(Object.isFrozen(snapshot)).toBe(true);
     expect(Object.isFrozen(snapshot.skills)).toBe(true);
+    expect(Object.isFrozen(snapshot.boilerplates[0]?.manifest)).toBe(true);
+    expect(Object.isFrozen(snapshot.boilerplates[0]?.manifest.skills)).toBe(true);
   });
 
   it("retains malformed boilerplate discoveries and reports a diagnostic", async () => {
@@ -65,6 +68,22 @@ describe("loadCatalogSnapshot", () => {
     );
     expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
       "INVALID_BOILERPLATE_MANIFEST",
+    );
+  });
+
+  it("retains nested artifact records when the parent manifest is malformed", async () => {
+    const fixture = await createCatalogFixture(await newRoot());
+    const dir = join(fixture.boilerplatesDir, "broken");
+    await mkdir(join(dir, "skills", "logger"), { recursive: true });
+    await writeSkill(join(dir, "skills", "logger"), "logger");
+    await writeWorkflow(join(dir, "workflow", "delivery"), "delivery");
+    await writeFile(join(dir, "boilerplate.json"), "{not-json", "utf8");
+    const snapshot = await loadCatalogSnapshot(fixture);
+    expect(snapshot.artifacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "skill", path: join(dir, "skills", "logger") }),
+        expect.objectContaining({ kind: "workflow", path: join(dir, "workflow", "delivery") }),
+      ]),
     );
   });
 
@@ -222,6 +241,36 @@ describe("loadCatalogSnapshot", () => {
     );
   });
 
+  it("excludes duplicate workflow identities from valid collections", async () => {
+    const fixture = await createCatalogFixture(await newRoot());
+    for (const directoryName of ["alpha", "beta"]) {
+      const dir = await writeBoilerplate(
+        fixture,
+        directoryName,
+        boilerplateManifest("demo", [], { name: "delivery", source: "local" }),
+      );
+      await writeWorkflow(join(dir, "workflow", "delivery"), "delivery");
+    }
+    const snapshot = await loadCatalogSnapshot(fixture);
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+      "DUPLICATE_ARTIFACT_IDENTITY",
+    );
+    expect(snapshot.workflows).toHaveLength(0);
+  });
+
+  it("renders every structured diagnostic from a strict validation error", async () => {
+    const fixture = await createCatalogFixture(await newRoot());
+    await writeBoilerplate(
+      fixture,
+      "demo",
+      boilerplateManifest("wrong", [{ name: "missing", source: "shared" }]),
+    );
+    const snapshot = await loadCatalogSnapshot(fixture);
+    expect(formatCatalogError(new CatalogValidationError(snapshot.diagnostics))).toHaveLength(
+      snapshot.diagnostics.length,
+    );
+  });
+
   it("orders diagnostics by path and code and exposes all errors from the gate", async () => {
     const fixture = await createCatalogFixture(await newRoot());
     await writeBoilerplate(
@@ -233,8 +282,9 @@ describe("loadCatalogSnapshot", () => {
     await writeSkill(join(localDir, "skills", "orphan"), "orphan");
 
     const snapshot = await loadCatalogSnapshot(fixture);
+    const compare = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
     const sorted = [...snapshot.diagnostics].sort(
-      (a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code),
+      (a, b) => compare(a.path, b.path) || compare(a.code, b.code),
     );
 
     expect(snapshot.diagnostics).toEqual(sorted);

--- a/tests/catalog-snapshot.test.ts
+++ b/tests/catalog-snapshot.test.ts
@@ -2,12 +2,18 @@ import { afterEach, describe, expect, it } from "vitest";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadCatalogSnapshot } from "../src/catalog-snapshot.js";
+import {
+  assertValidCatalog,
+  CatalogValidationError,
+  loadCatalogSnapshot,
+  type CatalogDiagnosticCode,
+} from "../src/catalog-snapshot.js";
 import {
   boilerplateManifest,
   createCatalogFixture,
   writeBoilerplate,
   writeSkill,
+  writeWorkflow,
 } from "./catalog-fixture.js";
 
 const roots: string[] = [];
@@ -74,5 +80,171 @@ describe("loadCatalogSnapshot", () => {
     expect(
       snapshot.diagnostics.filter((diagnostic) => diagnostic.code === "CATALOG_ROOT_UNREADABLE"),
     ).toHaveLength(3);
+  });
+
+  it.each<{
+    title: string;
+    code: CatalogDiagnosticCode;
+    arrange: (fixture: Awaited<ReturnType<typeof createCatalogFixture>>) => Promise<void>;
+  }>([
+    {
+      title: "missing declared shared skill",
+      code: "MISSING_DECLARED_SKILL",
+      arrange: async (fixture) => {
+        await writeBoilerplate(
+          fixture,
+          "demo",
+          boilerplateManifest("demo", [{ name: "absent", source: "shared" }]),
+        );
+      },
+    },
+    {
+      title: "undeclared local skill",
+      code: "UNDECLARED_LOCAL_SKILL",
+      arrange: async (fixture) => {
+        const dir = await writeBoilerplate(fixture, "demo", boilerplateManifest("demo"));
+        await writeSkill(join(dir, "skills", "logger"), "logger");
+      },
+    },
+    {
+      title: "duplicate declaration",
+      code: "DUPLICATE_SKILL_DECLARATION",
+      arrange: async (fixture) => {
+        await writeSkill(join(fixture.sharedSkillsDir, "logger"), "logger");
+        await writeBoilerplate(
+          fixture,
+          "demo",
+          boilerplateManifest("demo", [
+            { name: "logger", source: "shared" },
+            { name: "logger", source: "shared" },
+          ]),
+        );
+      },
+    },
+    {
+      title: "shared and local install-name collision",
+      code: "SKILL_INSTALL_NAME_COLLISION",
+      arrange: async (fixture) => {
+        await writeSkill(join(fixture.sharedSkillsDir, "logger"), "logger");
+        const dir = await writeBoilerplate(
+          fixture,
+          "demo",
+          boilerplateManifest("demo", [
+            { name: "logger", source: "shared" },
+            { name: "logger", source: "local" },
+          ]),
+        );
+        await writeSkill(join(dir, "skills", "logger"), "logger");
+      },
+    },
+    {
+      title: "missing declared workflow",
+      code: "MISSING_DECLARED_WORKFLOW",
+      arrange: async (fixture) => {
+        await writeBoilerplate(
+          fixture,
+          "demo",
+          boilerplateManifest("demo", [], { name: "delivery", source: "shared" }),
+        );
+      },
+    },
+    {
+      title: "directory and manifest mismatch",
+      code: "BOILERPLATE_NAME_MISMATCH",
+      arrange: async (fixture) => {
+        await writeBoilerplate(fixture, "folder-name", boilerplateManifest("manifest-name"));
+      },
+    },
+  ])("reports $title", async ({ arrange, code }) => {
+    const fixture = await createCatalogFixture(await newRoot());
+    await arrange(fixture);
+
+    const snapshot = await loadCatalogSnapshot(fixture);
+
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain(code);
+  });
+
+  it("allows equal local skill names in different boilerplates", async () => {
+    const fixture = await createCatalogFixture(await newRoot());
+    for (const boilerplateName of ["alpha", "beta"]) {
+      const dir = await writeBoilerplate(
+        fixture,
+        boilerplateName,
+        boilerplateManifest(boilerplateName, [{ name: "logger", source: "local" }]),
+      );
+      await writeSkill(join(dir, "skills", "logger"), "logger");
+    }
+
+    const snapshot = await loadCatalogSnapshot(fixture);
+
+    expect(snapshot.valid).toBe(true);
+    expect(snapshot.skills.map((skill) => skill.id)).toEqual(
+      expect.arrayContaining(["boilerplate:alpha/skills/logger", "boilerplate:beta/skills/logger"]),
+    );
+  });
+
+  it("resolves valid shared workflow metadata", async () => {
+    const fixture = await createCatalogFixture(await newRoot());
+    await writeWorkflow(join(fixture.sharedWorkflowsDir, "delivery"), "delivery");
+    await writeBoilerplate(
+      fixture,
+      "demo",
+      boilerplateManifest("demo", [], { name: "delivery", source: "shared" }),
+    );
+
+    const snapshot = await loadCatalogSnapshot(fixture);
+
+    expect(snapshot.valid).toBe(true);
+    expect(snapshot.workflows[0]?.id).toBe("shared:workflows/delivery");
+    expect(snapshot.boilerplates[0]?.workflow?.id).toBe("shared:workflows/delivery");
+  });
+
+  it("rejects a boilerplate without a template directory", async () => {
+    const fixture = await createCatalogFixture(await newRoot());
+    const dir = await writeBoilerplate(fixture, "demo", boilerplateManifest("demo"));
+    await rm(join(dir, "template"), { recursive: true, force: true });
+
+    const snapshot = await loadCatalogSnapshot(fixture);
+
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain("MISSING_TEMPLATE");
+    expect(snapshot.boilerplates).toHaveLength(0);
+  });
+
+  it("reports duplicate canonical artifact identities", async () => {
+    const fixture = await createCatalogFixture(await newRoot());
+    await writeBoilerplate(fixture, "demo", boilerplateManifest("demo"));
+    await writeBoilerplate(fixture, "duplicate-folder", boilerplateManifest("demo"));
+
+    const snapshot = await loadCatalogSnapshot(fixture);
+
+    expect(snapshot.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+      "DUPLICATE_ARTIFACT_IDENTITY",
+    );
+  });
+
+  it("orders diagnostics by path and code and exposes all errors from the gate", async () => {
+    const fixture = await createCatalogFixture(await newRoot());
+    await writeBoilerplate(
+      fixture,
+      "zeta",
+      boilerplateManifest("wrong", [{ name: "absent", source: "shared" }]),
+    );
+    const localDir = await writeBoilerplate(fixture, "alpha", boilerplateManifest("alpha"));
+    await writeSkill(join(localDir, "skills", "orphan"), "orphan");
+
+    const snapshot = await loadCatalogSnapshot(fixture);
+    const sorted = [...snapshot.diagnostics].sort(
+      (a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code),
+    );
+
+    expect(snapshot.diagnostics).toEqual(sorted);
+    expect(() => assertValidCatalog(snapshot)).toThrow(CatalogValidationError);
+    try {
+      assertValidCatalog(snapshot);
+    } catch (error) {
+      expect((error as CatalogValidationError).diagnostics).toHaveLength(
+        snapshot.diagnostics.filter((diagnostic) => diagnostic.severity === "error").length,
+      );
+    }
   });
 });

--- a/tests/catalog.test.ts
+++ b/tests/catalog.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { stat } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { listBoilerplates, getBoilerplate } from "../src/catalog.js";
 import { resolveSkillDirectory } from "../src/skills.js";
 import { defaultSharedSkillsDir } from "../src/paths.js";
+import { CatalogValidationError } from "../src/catalog-snapshot.js";
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -106,5 +108,18 @@ describe("catalog", () => {
 
   it("throws for an unknown boilerplate", async () => {
     await expect(getBoilerplate("does-not-exist")).rejects.toThrow(/Unknown boilerplate/);
+  });
+
+  it("does not silently skip an invalid boilerplate manifest", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bwai-catalog-invalid-"));
+    try {
+      const dir = join(root, "broken");
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "boilerplate.json"), "{bad-json", "utf8");
+
+      await expect(listBoilerplates(root)).rejects.toBeInstanceOf(CatalogValidationError);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/cli-list.test.ts
+++ b/tests/cli-list.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadCatalogSnapshot } from "../src/catalog-snapshot.js";
+import { runListBoilerplates } from "../src/list-boilerplates-command.js";
+import { boilerplateManifest, createCatalogFixture, writeBoilerplate } from "./catalog-fixture.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("runListBoilerplates", () => {
+  it("prints valid entries and diagnostics, then returns failure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bwai-cli-list-"));
+    roots.push(root);
+    const fixture = await createCatalogFixture(root);
+    await writeBoilerplate(fixture, "demo", boilerplateManifest("demo"));
+    const broken = join(fixture.boilerplatesDir, "broken");
+    await mkdir(broken, { recursive: true });
+    await writeFile(join(broken, "boilerplate.json"), "{bad-json", "utf8");
+    const snapshot = await loadCatalogSnapshot(fixture);
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const exitCode = await runListBoilerplates({
+      loadSnapshot: async () => snapshot,
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line),
+    });
+
+    expect(stdout.join("\n")).toContain("demo");
+    expect(stderr.join("\n")).toContain("INVALID_BOILERPLATE_MANIFEST");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/tests/cli-list.test.ts
+++ b/tests/cli-list.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, it } from "vitest";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadCatalogSnapshot } from "../src/catalog-snapshot.js";
+import {
+  CatalogValidationError,
+  formatCatalogError,
+  loadCatalogSnapshot,
+} from "../src/catalog-snapshot.js";
 import { runListBoilerplates } from "../src/list-boilerplates-command.js";
 import { boilerplateManifest, createCatalogFixture, writeBoilerplate } from "./catalog-fixture.js";
 
@@ -34,5 +38,20 @@ describe("runListBoilerplates", () => {
     expect(stdout.join("\n")).toContain("demo");
     expect(stderr.join("\n")).toContain("INVALID_BOILERPLATE_MANIFEST");
     expect(exitCode).toBe(1);
+  });
+
+  it("formats every diagnostic for strict command catches", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bwai-cli-errors-"));
+    roots.push(root);
+    const fixture = await createCatalogFixture(root);
+    await writeBoilerplate(
+      fixture,
+      "demo",
+      boilerplateManifest("wrong", [{ name: "missing", source: "shared" }]),
+    );
+    const snapshot = await loadCatalogSnapshot(fixture);
+    expect(formatCatalogError(new CatalogValidationError(snapshot.diagnostics))).toEqual(
+      snapshot.diagnostics.map((d) => `${d.code} ${d.path}: ${d.message}`),
+    );
   });
 });

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { runDoctor, formatDoctorReport } from "../src/doctor.js";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createCatalogFixture } from "./catalog-fixture.js";
 
 describe("doctor", () => {
   it("returns checks including node, catalog, and global-advisor", async () => {
@@ -19,5 +23,22 @@ describe("doctor", () => {
     const text = formatDoctorReport(report);
     expect(text).toContain("node:");
     expect(text).toContain("catalog:");
+  });
+
+  it("reports accumulated catalog diagnostics as a failed check", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bwai-doctor-catalog-"));
+    try {
+      const fixture = await createCatalogFixture(root);
+      const broken = join(fixture.boilerplatesDir, "broken");
+      await mkdir(broken, { recursive: true });
+      await writeFile(join(broken, "boilerplate.json"), "{bad-json", "utf8");
+
+      const report = await runDoctor(root, { catalogRoots: fixture });
+      const catalog = report.checks.find((check) => check.name === "catalog");
+      expect(catalog?.status).toBe("fail");
+      expect(catalog?.message).toContain("1 error");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/export-plugin.test.ts
+++ b/tests/export-plugin.test.ts
@@ -6,7 +6,12 @@ import { exportPlugin } from "../src/export-plugin.js";
 import { scaffold } from "../src/scaffold.js";
 import { validateAgentPlugin } from "../src/plugin.js";
 import { CatalogValidationError } from "../src/catalog-snapshot.js";
-import { boilerplateManifest, createCatalogFixture, writeBoilerplate } from "./catalog-fixture.js";
+import {
+  boilerplateManifest,
+  createCatalogFixture,
+  writeBoilerplate,
+  writeSkill,
+} from "./catalog-fixture.js";
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -79,5 +84,16 @@ describe("export-plugin", () => {
       exportPlugin({ source: "demo", outDir: out, catalogRoots: fixture }),
     ).rejects.toBeInstanceOf(CatalogValidationError);
     expect(await exists(out)).toBe(false);
+  });
+
+  it("exports an existing project without depending on catalog validity", async () => {
+    const fixture = await createCatalogFixture(join(dir, "invalid-catalog-for-project"));
+    await writeBoilerplate(fixture, "broken", boilerplateManifest("wrong"));
+    const project = join(dir, "standalone-project");
+    await writeSkill(join(project, ".bwai", "skills", "demo"), "demo");
+    const out = join(dir, "standalone-export");
+    const result = await exportPlugin({ source: project, outDir: out, catalogRoots: fixture });
+    expect(result.sourceKind).toBe("project");
+    expect(await exists(join(out, "skills", "demo", "SKILL.md"))).toBe(true);
   });
 });

--- a/tests/export-plugin.test.ts
+++ b/tests/export-plugin.test.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 import { exportPlugin } from "../src/export-plugin.js";
 import { scaffold } from "../src/scaffold.js";
 import { validateAgentPlugin } from "../src/plugin.js";
+import { CatalogValidationError } from "../src/catalog-snapshot.js";
+import { boilerplateManifest, createCatalogFixture, writeBoilerplate } from "./catalog-fixture.js";
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -62,5 +64,20 @@ describe("export-plugin", () => {
     expect(result.manifest.name).toBe("bwai.node-service");
     expect(result.skillNames.length).toBeGreaterThan(0);
     expect(await exists(join(out, "skills", "code-review", "SKILL.md"))).toBe(true);
+  });
+
+  it("validates a boilerplate catalog before creating output", async () => {
+    const fixture = await createCatalogFixture(join(dir, "invalid-catalog"));
+    await writeBoilerplate(
+      fixture,
+      "demo",
+      boilerplateManifest("demo", [{ name: "missing", source: "shared" }]),
+    );
+    const out = join(dir, "invalid-output");
+
+    await expect(
+      exportPlugin({ source: "demo", outDir: out, catalogRoots: fixture }),
+    ).rejects.toBeInstanceOf(CatalogValidationError);
+    expect(await exists(out)).toBe(false);
   });
 });

--- a/tests/install-skill.test.ts
+++ b/tests/install-skill.test.ts
@@ -3,6 +3,13 @@ import { mkdtemp, rm, readFile, access } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { installSkill, listInstallableSkills, SKILL_DEPENDENCIES } from "../src/install-skill.js";
+import { CatalogValidationError } from "../src/catalog-snapshot.js";
+import {
+  boilerplateManifest,
+  createCatalogFixture,
+  writeBoilerplate,
+  writeSkill,
+} from "./catalog-fixture.js";
 
 describe("installSkill", () => {
   let home: string;
@@ -75,5 +82,14 @@ describe("installSkill", () => {
         withDeps: false,
       }),
     ).rejects.toThrow(/Unknown skill.*bwai-advisor/s);
+  });
+
+  it("rejects invalid catalog state before listing installable skills", async () => {
+    const fixture = await createCatalogFixture(join(home, "catalog"));
+    await writeSkill(join(fixture.sharedSkillsDir, "demo"), "demo");
+    await writeBoilerplate(fixture, "broken", boilerplateManifest("wrong"));
+    await expect(listInstallableSkills({ catalogRoots: fixture })).rejects.toBeInstanceOf(
+      CatalogValidationError,
+    );
   });
 });

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -11,7 +11,7 @@ import {
 import { syncSkills } from "../src/sync-skills.js";
 import { promoteSkill } from "../src/promote.js";
 import type { SkillScanner } from "../src/scan.js";
-import { loadCatalogSnapshot } from "../src/catalog-snapshot.js";
+import { CatalogValidationError, loadCatalogSnapshot } from "../src/catalog-snapshot.js";
 import {
   boilerplateManifest,
   createCatalogFixture,
@@ -192,12 +192,56 @@ describe("syncSkills", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("validates custom catalog roots before changing manifests", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "bwai-sync-invalid-"));
+    try {
+      const fixture = await createCatalogFixture(join(dir, "catalog"));
+      const boilerplateDir = await writeBoilerplate(
+        fixture,
+        "demo",
+        boilerplateManifest("demo", [{ name: "code-review", source: "shared" }]),
+      );
+      const registryPath = join(dir, "registry.json");
+      await saveRegistry(
+        {
+          indexVersion: 2,
+          updatedAt: new Date().toISOString(),
+          skills: [
+            {
+              id: "shared:project-security",
+              name: "project-security",
+              catalogLocation: "shared",
+              catalogPath: "shared/skills/project-security",
+              promotedAt: new Date().toISOString(),
+              sha256: "abc",
+              scan: { status: "pending", riskScore: null, scannedAt: null, threshold: 30 },
+              bundleAll: true,
+              bundledIn: [],
+            },
+          ],
+        },
+        registryPath,
+      );
+
+      await expect(syncSkills({ registryPath, catalogRoots: fixture })).rejects.toBeInstanceOf(
+        CatalogValidationError,
+      );
+      const manifest = JSON.parse(
+        await readFile(join(boilerplateDir, "boilerplate.json"), "utf8"),
+      ) as { skills: Array<{ name: string }> };
+      expect(manifest.skills.map((skill) => skill.name)).toEqual(["code-review"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("promoteSkill", () => {
   it("copies a local skill into shared and updates the registry", async () => {
     const dir = await mkdtemp(join(tmpdir(), "bwai-promote-"));
     try {
+      const fixture = await createCatalogFixture(join(dir, "catalog"));
       const source = join(dir, "source", "demo-skill");
       await mkdir(source, { recursive: true });
       await writeFile(
@@ -205,19 +249,20 @@ describe("promoteSkill", () => {
         "---\nname: demo-skill\ndescription: Use when testing skill promotion into the shared catalog.\nlicense: MIT\n---\n\n# Demo\n",
       );
 
-      const sharedDir = join(dir, "shared", "skills");
       const registryPath = join(dir, "registry.json");
 
       const result = await promoteSkill({
         skillName: "demo-skill",
         fromPath: source,
         scanner: fakeScanner(0),
-        sharedSkillsDir: sharedDir,
+        catalogRoots: fixture,
         registryPath,
       });
 
       expect(result.dryRun).toBe(false);
-      expect(await readFile(join(sharedDir, "demo-skill", "SKILL.md"), "utf8")).toContain("# Demo");
+      expect(
+        await readFile(join(fixture.sharedSkillsDir, "demo-skill", "SKILL.md"), "utf8"),
+      ).toContain("# Demo");
       const index = await loadRegistry(registryPath);
       expect(index.skills.some((s) => s.name === "demo-skill")).toBe(true);
     } finally {
@@ -228,6 +273,7 @@ describe("promoteSkill", () => {
   it("blocks promotion when risk exceeds threshold", async () => {
     const dir = await mkdtemp(join(tmpdir(), "bwai-promote-block-"));
     try {
+      const fixture = await createCatalogFixture(join(dir, "catalog"));
       const source = join(dir, "source", "risky-skill");
       await mkdir(source, { recursive: true });
       await writeFile(
@@ -241,10 +287,39 @@ describe("promoteSkill", () => {
           fromPath: source,
           scanner: fakeScanner(99),
           threshold: 30,
-          sharedSkillsDir: join(dir, "shared", "skills"),
+          catalogRoots: fixture,
           registryPath: join(dir, "registry.json"),
         }),
       ).rejects.toThrow(/exceeds threshold/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("validates existing catalog state before copying a promoted skill", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "bwai-promote-invalid-"));
+    try {
+      const fixture = await createCatalogFixture(join(dir, "catalog"));
+      await writeBoilerplate(
+        fixture,
+        "demo",
+        boilerplateManifest("demo", [{ name: "code-review", source: "shared" }]),
+      );
+      const source = join(dir, "source", "demo-skill");
+      await writeSkill(source, "demo-skill");
+
+      await expect(
+        promoteSkill({
+          skillName: "demo-skill",
+          fromPath: source,
+          scanner: fakeScanner(),
+          registryPath: join(dir, "registry.json"),
+          catalogRoots: fixture,
+        }),
+      ).rejects.toBeInstanceOf(CatalogValidationError);
+      await expect(
+        readFile(join(fixture.sharedSkillsDir, "demo-skill", "SKILL.md")),
+      ).rejects.toThrow();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -88,6 +88,35 @@ describe("registry", () => {
     expect(JSON.parse(await readFile(registryPath, "utf8")).indexVersion).toBe(2);
   });
 
+  it("rejects conflicting local ownership during version 1 migration", async () => {
+    await writeFile(
+      registryPath,
+      `${JSON.stringify({
+        indexVersion: 1,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        skills: [
+          {
+            name: "logger",
+            catalogLocation: "local",
+            catalogPath: "boilerplates/alpha/skills/logger",
+            promotedAt: "2026-01-01T00:00:00.000Z",
+            sha256: "abc",
+            scan: { status: "pending", riskScore: null, scannedAt: null, threshold: 30 },
+            bundledIn: ["beta"],
+          },
+        ],
+      })}\n`,
+      "utf8",
+    );
+    await expect(loadRegistry(registryPath)).rejects.toThrow(/conflicting|ambiguous/i);
+  });
+
+  it("does not ignore a malformed existing registry during rebuild", async () => {
+    await writeFile(registryPath, "{bad-json", "utf8");
+    await expect(buildRegistryFromCatalog({ registryPath })).rejects.toThrow();
+    expect(await readFile(registryPath, "utf8")).toBe("{bad-json");
+  });
+
   it("preserves same-named local skills under different canonical identities", async () => {
     const fixture = await createCatalogFixture(join(dir, "catalog"));
     for (const name of ["alpha", "beta"]) {

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -2,10 +2,22 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, readFile, writeFile, mkdir, cp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildRegistryFromCatalog, loadRegistry, saveRegistry } from "../src/registry.js";
+import {
+  applyCatalogScanToRegistry,
+  buildRegistryFromCatalog,
+  loadRegistry,
+  saveRegistry,
+} from "../src/registry.js";
 import { syncSkills } from "../src/sync-skills.js";
 import { promoteSkill } from "../src/promote.js";
 import type { SkillScanner } from "../src/scan.js";
+import { loadCatalogSnapshot } from "../src/catalog-snapshot.js";
+import {
+  boilerplateManifest,
+  createCatalogFixture,
+  writeBoilerplate,
+  writeSkill,
+} from "./catalog-fixture.js";
 
 function fakeScanner(risk = 0): SkillScanner {
   return {
@@ -34,8 +46,9 @@ describe("registry", () => {
 
   it("builds an index from the repo catalog", async () => {
     const index = await buildRegistryFromCatalog({ registryPath });
-    expect(index.indexVersion).toBe(1);
+    expect(index.indexVersion).toBe(2);
     expect(index.skills.some((s) => s.name === "code-review")).toBe(true);
+    expect(index.skills.find((s) => s.name === "code-review")?.id).toBe("shared:code-review");
     expect(index.skills.every((s) => s.sha256.length === 64)).toBe(true);
   });
 
@@ -44,6 +57,70 @@ describe("registry", () => {
     await saveRegistry(index, registryPath);
     const loaded = await loadRegistry(registryPath);
     expect(loaded.skills.length).toBe(index.skills.length);
+  });
+
+  it("loads a version 1 registry and migrates it in memory", async () => {
+    await writeFile(
+      registryPath,
+      `${JSON.stringify({
+        indexVersion: 1,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        skills: [
+          {
+            name: "code-review",
+            catalogLocation: "shared",
+            catalogPath: "shared/skills/code-review",
+            promotedAt: "2026-01-01T00:00:00.000Z",
+            sha256: "abc",
+            scan: { status: "pending", riskScore: null, scannedAt: null, threshold: 30 },
+            bundleAll: false,
+            bundledIn: [],
+          },
+        ],
+      })}\n`,
+      "utf8",
+    );
+
+    const migrated = await loadRegistry(registryPath);
+    expect(migrated.indexVersion).toBe(2);
+    expect(migrated.skills[0]?.id).toBe("shared:code-review");
+    await saveRegistry(migrated, registryPath);
+    expect(JSON.parse(await readFile(registryPath, "utf8")).indexVersion).toBe(2);
+  });
+
+  it("preserves same-named local skills under different canonical identities", async () => {
+    const fixture = await createCatalogFixture(join(dir, "catalog"));
+    for (const name of ["alpha", "beta"]) {
+      const boilerplateDir = await writeBoilerplate(
+        fixture,
+        name,
+        boilerplateManifest(name, [{ name: "logger", source: "local" }]),
+      );
+      await writeSkill(join(boilerplateDir, "skills", "logger"), "logger");
+    }
+    const snapshot = await loadCatalogSnapshot(fixture);
+
+    const index = await buildRegistryFromCatalog({ registryPath, snapshot });
+
+    expect(index.skills.map((skill) => skill.id)).toEqual(
+      expect.arrayContaining(["boilerplate:alpha/skills/logger", "boilerplate:beta/skills/logger"]),
+    );
+  });
+
+  it("applies scan results by canonical identity", async () => {
+    const index = await buildRegistryFromCatalog({ registryPath });
+    const updated = applyCatalogScanToRegistry(index, [
+      {
+        id: "shared:code-review",
+        label: "presentation-label-that-does-not-match",
+        riskScore: 12,
+        status: "passed",
+      },
+    ]);
+
+    expect(updated.skills.find((skill) => skill.id === "shared:code-review")?.scan.riskScore).toBe(
+      12,
+    );
   });
 });
 
@@ -80,10 +157,11 @@ describe("syncSkills", () => {
 
       await saveRegistry(
         {
-          indexVersion: 1,
+          indexVersion: 2,
           updatedAt: new Date().toISOString(),
           skills: [
             {
+              id: "shared:project-security",
               name: "project-security",
               catalogLocation: "shared",
               catalogPath: "shared/skills/project-security",

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { scaffold } from "../src/scaffold.js";
 import { readLock } from "../src/provenance.js";
+import { CatalogValidationError } from "../src/catalog-snapshot.js";
+import { boilerplateManifest, createCatalogFixture, writeBoilerplate } from "./catalog-fixture.js";
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -219,6 +221,26 @@ describe("scaffold", () => {
     await expect(
       scaffold({ boilerplateName: "node-service", targetDir: target, agents: ["claude"] }),
     ).rejects.toThrow(/not empty/);
+  });
+
+  it("validates the catalog before creating the target", async () => {
+    const fixture = await createCatalogFixture(join(dir, "invalid-catalog"));
+    await writeBoilerplate(
+      fixture,
+      "demo",
+      boilerplateManifest("demo", [{ name: "missing", source: "shared" }]),
+    );
+    const target = join(dir, "invalid-target");
+
+    await expect(
+      scaffold({
+        boilerplateName: "demo",
+        targetDir: target,
+        agents: ["claude"],
+        catalogRoots: fixture,
+      }),
+    ).rejects.toBeInstanceOf(CatalogValidationError);
+    expect(await exists(target)).toBe(false);
   });
 
   it("produces a runnable project (SKILL.md content hashes are stable)", async () => {

--- a/tests/upstream-sync.test.ts
+++ b/tests/upstream-sync.test.ts
@@ -64,10 +64,11 @@ describe("syncUpstreamSkills", () => {
 
     await saveRegistry(
       {
-        indexVersion: 1,
+        indexVersion: 2,
         updatedAt: new Date().toISOString(),
         skills: [
           {
+            id: "shared:demo-skill",
             name: "demo-skill",
             catalogLocation: "shared",
             catalogPath: "shared/skills/demo-skill",

--- a/tests/upstream-sync.test.ts
+++ b/tests/upstream-sync.test.ts
@@ -4,8 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
 import { syncUpstreamSkills } from "../src/upstream-sync.js";
-import { saveRegistry } from "../src/registry.js";
+import { loadRegistry, saveRegistry } from "../src/registry.js";
 import type { SkillScanner } from "../src/scan.js";
+import { createCatalogFixture, type CatalogFixture } from "./catalog-fixture.js";
 
 function fakeScanner(risk = 0): SkillScanner {
   return {
@@ -42,24 +43,26 @@ describe("syncUpstreamSkills", () => {
   let upstreamRepo: string;
   let sharedDir: string;
   let registryPath: string;
+  let catalogRoots: CatalogFixture;
 
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "bwai-upstream-"));
     upstreamRepo = join(root, "upstream.git");
-    sharedDir = join(root, "shared", "skills");
+    catalogRoots = await createCatalogFixture(join(root, "catalog"));
+    sharedDir = catalogRoots.sharedSkillsDir;
     registryPath = join(root, "registry.json");
 
     await mkdir(join(upstreamRepo, "skills", "demo-skill"), { recursive: true });
     await writeFile(
       join(upstreamRepo, "skills", "demo-skill", "SKILL.md"),
-      "---\nname: demo-skill\ndescription: upstream\n---\n\n# Upstream v2\n",
+      "---\nname: demo-skill\ndescription: Use when testing upstream skill synchronization behavior.\nlicense: MIT\n---\n\n# Upstream v2\n",
     );
     await initGitRepo(upstreamRepo);
 
     await mkdir(join(sharedDir, "demo-skill"), { recursive: true });
     await writeFile(
       join(sharedDir, "demo-skill", "SKILL.md"),
-      "---\nname: demo-skill\ndescription: local\n---\n\n# Local v1\n",
+      "---\nname: demo-skill\ndescription: Use when testing local skill synchronization behavior.\nlicense: MIT\n---\n\n# Local v1\n",
     );
 
     await saveRegistry(
@@ -95,7 +98,7 @@ describe("syncUpstreamSkills", () => {
   it("reports drift without --apply", async () => {
     const result = await syncUpstreamSkills({
       registryPath,
-      sharedSkillsDir: sharedDir,
+      catalogRoots,
       scanner: fakeScanner(),
     });
     expect(result.entries).toHaveLength(1);
@@ -107,12 +110,34 @@ describe("syncUpstreamSkills", () => {
   it("applies upstream content when --apply and scan passes", async () => {
     const result = await syncUpstreamSkills({
       registryPath,
-      sharedSkillsDir: sharedDir,
+      catalogRoots,
       scanner: fakeScanner(0),
       apply: true,
     });
     expect(result.entries[0]?.status).toBe("updated");
     const content = await readFile(join(sharedDir, "demo-skill", "SKILL.md"), "utf8");
     expect(content).toContain("Upstream v2");
+  });
+
+  it("resolves --skill names only among shared canonical identities", async () => {
+    const index = await loadRegistry(registryPath);
+    index.skills.unshift({
+      ...index.skills[0]!,
+      id: "boilerplate:demo/skills/demo-skill",
+      catalogLocation: "local",
+      catalogPath: "boilerplates/demo/skills/demo-skill",
+      bundledIn: ["demo"],
+    });
+    await saveRegistry(index, registryPath);
+
+    const result = await syncUpstreamSkills({
+      registryPath,
+      catalogRoots,
+      scanner: fakeScanner(),
+      skillName: "demo-skill",
+    });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]?.status).toBe("drift");
   });
 });

--- a/tests/workflows.test.ts
+++ b/tests/workflows.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { join } from "node:path";
 import { defaultSharedWorkflowsDir } from "../src/paths.js";
 import { assertWorkflowExists, resolveWorkflowDirectory } from "../src/workflows.js";
+import { workflowManifestSchema } from "../src/schema.js";
 
 describe("workflows", () => {
   it("resolves shared workflow directory", () => {
@@ -23,5 +24,27 @@ describe("workflows", () => {
   it("assertWorkflowExists passes for bwai-delivery", async () => {
     const dir = join(defaultSharedWorkflowsDir(), "bwai-delivery");
     await expect(assertWorkflowExists(dir, "bwai-delivery")).resolves.toBeUndefined();
+  });
+
+  it("validates workflow metadata and rejects duplicate step ids", () => {
+    const base = {
+      schemaVersion: "0.1",
+      name: "demo-flow",
+      version: "1.0.0",
+      description: "Demo workflow",
+      skills: [{ source: "./skills/demo" }],
+      steps: [
+        { id: "shape", title: "Shape", skill: "brainstorming" },
+        { id: "shape", title: "Build", skill: "implementation" },
+      ],
+    };
+
+    expect(workflowManifestSchema.safeParse(base).success).toBe(false);
+    expect(
+      workflowManifestSchema.safeParse({
+        ...base,
+        steps: [{ id: "shape", title: "Shape", skill: "brainstorming" }],
+      }).success,
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add one immutable catalog snapshot for boilerplates, skills, and workflows
- validate metadata, identities, and cross-artifact relationships before strict operations
- migrate registry to canonical identity-based v2 with safe v1 read migration
- route scanning, scaffold, export, promotion, sync, install, workflows, and doctor through snapshot state
- report complete structured diagnostics and preserve project-only plugin exports

## Verification
- npm test (20 files, 105 tests)
- npm run typecheck
- npm run lint
- npm run build
- node dist/cli.js list-boilerplates
- node dist/cli.js list-workflows
- node dist/cli.js doctor
- npm pack --dry-run

Independent code review and focused re-review found no remaining Critical or Important issues.